### PR TITLE
feat(us-01): autenticação e gestão de usuários

### DIFF
--- a/backend/alembic/versions/20260327_0002_add_name_to_users.py
+++ b/backend/alembic/versions/20260327_0002_add_name_to_users.py
@@ -1,0 +1,28 @@
+"""add name to users
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("name", sa.String(128), nullable=True))
+    op.execute("UPDATE users SET name = '' WHERE name IS NULL")
+    op.alter_column("users", "name", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "name")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -12,6 +12,7 @@ class User(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
     hashed_password: Mapped[str] = mapped_column(String(128), nullable=False)
     role: Mapped[str] = mapped_column(String(16), nullable=False, default="user")
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class LoginRequest(BaseModel):
@@ -16,7 +16,20 @@ class TokenResponse(BaseModel):
 
 class UserCreate(BaseModel):
     username: str = Field(min_length=3, max_length=64)
+    name: str = Field(min_length=1, max_length=128)
     password: str = Field(min_length=8)
+
+    @field_validator("username")
+    @classmethod
+    def username_format(cls, v: str) -> str:
+        import re
+
+        if not re.fullmatch(r"[a-z0-9_.]+", v):
+            raise ValueError(
+                "Username deve conter apenas letras minúsculas, "
+                "dígitos, ponto ou sublinhado."
+            )
+        return v
 
 
 class ChangePasswordRequest(BaseModel):
@@ -31,6 +44,7 @@ class ResetPasswordRequest(BaseModel):
 class UserOut(BaseModel):
     id: uuid.UUID
     username: str
+    name: str
     role: str
     created_at: datetime
     is_active: bool

--- a/backend/services/user.py
+++ b/backend/services/user.py
@@ -20,6 +20,7 @@ def create_user(db: Session, data: UserCreate) -> User:
         )
     user = User(
         username=data.username,
+        name=data.name,
         hashed_password=get_password_hash(data.password),
         role="user",
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,6 +41,7 @@ def client(db):
 def admin_user(db):
     user = User(
         username="admin",
+        name="Admin Teste",
         hashed_password=get_password_hash("adminpass1"),
         role="admin",
     )
@@ -54,6 +55,7 @@ def admin_user(db):
 def regular_user(db):
     user = User(
         username="user1",
+        name="Usuário Teste",
         hashed_password=get_password_hash("userpass1!"),
         role="user",
     )
@@ -83,6 +85,7 @@ def fake_admin():
     return User(
         id=uuid.uuid4(),
         username="admin",
+        name="Admin Fake",
         hashed_password="hash",
         role="admin",
         is_active=True,
@@ -95,6 +98,7 @@ def fake_user():
     return User(
         id=uuid.uuid4(),
         username="user1",
+        name="Usuário Fake",
         hashed_password="hash",
         role="user",
         is_active=True,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,6 +6,7 @@ def test_login_valid_credentials_returns_jwt(client, db):
     """Fake: banco SQLite com usuário pré-criado. Bcrypt real."""
     user = User(
         username="testuser",
+        name="Usuário Teste",
         hashed_password=get_password_hash("password123"),
         role="user",
     )
@@ -24,7 +25,12 @@ def test_login_valid_credentials_returns_jwt(client, db):
 
 def test_login_invalid_credentials_returns_generic_401(client, db, mocker):
     """Stub: verify_password retorna False. Mensagem não revela qual campo falhou."""
-    user = User(username="testuser", hashed_password="some_hash", role="user")
+    user = User(
+        username="testuser",
+        name="Usuário Teste",
+        hashed_password="some_hash",
+        role="user",
+    )
     db.add(user)
     db.commit()
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -29,11 +29,12 @@ def test_admin_can_create_user(client, db, fake_admin):
 
     response = client.post(
         "/users/",
-        json={"username": "newuser", "password": "password123"},
+        json={"username": "newuser", "name": "Novo Usuário", "password": "password123"},
     )
     assert response.status_code == 201
     data = response.json()
     assert data["username"] == "newuser"
+    assert data["name"] == "Novo Usuário"
     assert data["role"] == "user"
     assert "id" in data
     assert "created_at" in data
@@ -45,6 +46,7 @@ def test_create_user_duplicate_username_returns_409(client, db, fake_admin):
 
     existing = User(
         username="duplicate",
+        name="Usuário Duplicado",
         hashed_password=get_password_hash("pass1234"),
         role="user",
     )
@@ -53,7 +55,7 @@ def test_create_user_duplicate_username_returns_409(client, db, fake_admin):
 
     response = client.post(
         "/users/",
-        json={"username": "duplicate", "password": "password123"},
+        json={"username": "duplicate", "name": "Outro Nome", "password": "password123"},
     )
     assert response.status_code == 409
 
@@ -80,7 +82,32 @@ def test_create_user_short_password_returns_422(client, fake_admin):
 
     response = client.post(
         "/users/",
-        json={"username": "newuser", "password": "short"},
+        json={"username": "newuser", "name": "Novo Usuário", "password": "short"},
+    )
+    assert response.status_code == 422
+
+
+def test_create_user_invalid_username_returns_422(client, fake_admin):
+    """Username com caracteres inválidos (maiúsculas, espaço) retorna 422."""
+    app.dependency_overrides[get_current_user] = lambda: fake_admin
+
+    for bad_username in ("NewUser", "new user", "new@user", "NEW"):
+        response = client.post(
+            "/users/",
+            json={"username": bad_username, "name": "Teste", "password": "password123"},
+        )
+        assert (
+            response.status_code == 422
+        ), f"esperado 422 para username={bad_username!r}"
+
+
+def test_create_user_missing_name_returns_422(client, fake_admin):
+    """Campo name ausente retorna 422 (validação Pydantic)."""
+    app.dependency_overrides[get_current_user] = lambda: fake_admin
+
+    response = client.post(
+        "/users/",
+        json={"username": "newuser", "password": "password123"},
     )
     assert response.status_code == 422
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -3,6 +3,7 @@ import { request } from "./http";
 export interface UserOut {
   id: string;
   username: string;
+  name: string;
   role: string;
   created_at: string;
   is_active: boolean;
@@ -10,6 +11,7 @@ export interface UserOut {
 
 export interface UserCreate {
   username: string;
+  name: string;
   password: string;
 }
 

--- a/frontend/src/pages/Users/CreateUserModal.tsx
+++ b/frontend/src/pages/Users/CreateUserModal.tsx
@@ -8,6 +8,7 @@ interface Props {
 
 export function CreateUserModal({ onClose, onCreate }: Props) {
   const [username, setUsername] = useState("");
+  const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -17,7 +18,7 @@ export function CreateUserModal({ onClose, onCreate }: Props) {
     setError(null);
     setLoading(true);
     try {
-      await onCreate({ username, password });
+      await onCreate({ username, name, password });
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro ao criar usuário");
@@ -49,6 +50,23 @@ export function CreateUserModal({ onClose, onCreate }: Props) {
         <form onSubmit={handleSubmit} noValidate>
           <div className="px-6 pt-6">
             <div className="form-group">
+              <label className="form-label" htmlFor="new-name">
+                Nome
+              </label>
+              <input
+                id="new-name"
+                className="form-input"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                maxLength={128}
+                autoFocus
+                placeholder="Nome completo do pesquisador"
+              />
+            </div>
+
+            <div className="form-group">
               <label className="form-label" htmlFor="new-username">
                 Usuário
               </label>
@@ -61,8 +79,7 @@ export function CreateUserModal({ onClose, onCreate }: Props) {
                 required
                 minLength={3}
                 maxLength={64}
-                autoFocus
-                placeholder="mínimo 3 caracteres"
+                placeholder="apenas minúsculas, dígitos, ponto ou _"
               />
             </div>
 

--- a/frontend/src/pages/Users/UsersPage.tsx
+++ b/frontend/src/pages/Users/UsersPage.tsx
@@ -141,15 +141,20 @@ export function UsersPage() {
                       ].join(" ")}
                     >
                       <td className="px-5 py-3.5 align-middle">
-                        <div
-                          className={`flex items-center gap-2.5 font-medium ${u.is_active ? "text-gray-800" : "text-gray-400"}`}
-                        >
+                        <div className="flex items-center gap-2.5">
                           <span
                             className={`w-[30px] h-[30px] rounded-full text-white text-[13px] font-bold inline-flex items-center justify-center flex-shrink-0 ${u.is_active ? "bg-davint-400" : "bg-gray-300"}`}
                           >
-                            {u.username[0].toUpperCase()}
+                            {u.name[0].toUpperCase()}
                           </span>
-                          {u.username}
+                          <div>
+                            <div
+                              className={`font-medium ${u.is_active ? "text-gray-800" : "text-gray-400"}`}
+                            >
+                              {u.name}
+                            </div>
+                            <div className="text-xs text-gray-400">@{u.username}</div>
+                          </div>
                         </div>
                       </td>
                       <td className="px-5 py-3.5 align-middle">


### PR DESCRIPTION
## O que mudou

Release da US-01 — autenticação JWT e gestão de usuários.

- Login/logout com JWT (`POST /auth/login`, `POST /auth/logout`)
- CRUD de usuários: criar, listar, desativar (soft-delete), reativar
- Troca e reset de senha
- Campo `name` (nome do pesquisador) separado de `username`
- Validação de `username`: apenas minúsculas, dígitos, `.` ou `_`
- Migration `0002`: adiciona coluna `name` à tabela `users`
- Frontend: tela de login e gestão de usuários com os 3 campos
- CI verde: 24 testes, cobertura 95%

## Deploy pós-merge

```bash
alembic upgrade head
