### PR TITLE
fix(collect): erros descritivos em vez de mensagens genéricas

### DIFF
--- a/.claude/backend.md
+++ b/.claude/backend.md
@@ -121,6 +121,42 @@ result = youtube_client.fetch(api_key=payload.api_key.get_secret_value())
 - Nunca logar `SecretStr`, tokens JWT ou senhas
 - Bandit e Ruff devem passar sem warnings antes de qualquer commit
 
+## Tratamento de erros
+
+Toda HTTPException deve ter `detail` descritivo para o usuário final. Mensagens genéricas como "Erro inesperado" são proibidas — sempre incluir o contexto do que falhou.
+
+### Regras
+
+1. **detail descritivo**: toda HTTPException deve explicar **o que** falhou e **o que o usuário pode fazer**
+2. **Logar antes de lançar**: exceções inesperadas devem ser logadas com `logger.exception()` antes de virar HTTPException
+3. **Não engolir exceções**: `except Exception` sem log é proibido — no mínimo `logger.warning()` ou `logger.exception()`
+4. **Erros de APIs externas**: parsear a resposta e traduzir para mensagem amigável em português
+5. **Incluir contexto**: quando possível, incluir IDs e valores relevantes no log (nunca secrets)
+
+### Padrão
+
+```python
+# ✅ Correto — descritivo, com log
+try:
+    result = await external_api_call()
+except httpx.HTTPStatusError as exc:
+    logger.exception("Falha na API externa para video_id=%s", video_id)
+    raise HTTPException(
+        status.HTTP_502_BAD_GATEWAY,
+        detail="Falha ao comunicar com a API do YouTube. Tente novamente.",
+    ) from exc
+except Exception as exc:
+    logger.exception("Erro inesperado ao coletar video_id=%s", video_id)
+    raise HTTPException(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Erro interno ao processar a coleta. Tente novamente ou contate o administrador.",
+    ) from exc
+
+# ❌ Errado — genérico, sem log
+except Exception:
+    raise HTTPException(500, detail="Erro inesperado.")
+```
+
 ## Padrões de teste Pytest
 
 ```python

--- a/backend/services/collect.py
+++ b/backend/services/collect.py
@@ -33,8 +33,16 @@ def _parse_youtube_error(exc: httpx.HTTPStatusError) -> HTTPException:
         body = exc.response.json()
         errors = body.get("error", {}).get("errors", [])
         reason = errors[0].get("reason", "") if errors else ""
+        message = errors[0].get("message", "") if errors else ""
     except Exception:
         reason = ""
+        message = ""
+    logger.warning(
+        "YouTube API %s reason=%s message=%s",
+        http_status,
+        reason,
+        message,
+    )
 
     if http_status == 400:
         if reason in ("keyInvalid", "keyExpired"):
@@ -69,8 +77,8 @@ def _parse_youtube_error(exc: httpx.HTTPStatusError) -> HTTPException:
     if http_status == 404:
         return HTTPException(status.HTTP_404_NOT_FOUND, detail="Vídeo não encontrado.")
     return HTTPException(
-        status.HTTP_400_BAD_REQUEST,
-        detail="Erro na comunicação com o YouTube.",
+        status.HTTP_502_BAD_GATEWAY,
+        detail=f"Erro na API do YouTube (HTTP {http_status}). Tente novamente.",
     )
 
 
@@ -238,9 +246,11 @@ async def _enrich_channel_dates(
         db.commit()
         return True
     except Exception:
-        logger.warning(
-            "Falha ao buscar datas de criação de canais — coleta %s.",
+        logger.exception(
+            "Falha ao buscar datas de criação de canais para coleta %s "
+            "(%d canais solicitados)",
             collection_id,
+            len(channel_ids),
         )
         return False
 
@@ -320,17 +330,26 @@ async def start_collection(
         db.refresh(collection)
         return collection, next_page_token
     except httpx.HTTPStatusError as exc:
+        logger.exception(
+            "YouTube API erro HTTP %s para video_id=%s",
+            exc.response.status_code,
+            payload.video_id,
+        )
         collection.status = "failed"
-        collection.error_message = "Erro na comunicação com o YouTube."
+        collection.error_message = str(exc)[:500]
         db.commit()
         raise _parse_youtube_error(exc) from exc
     except Exception as exc:
+        logger.exception(
+            "Erro inesperado na coleta do video_id=%s",
+            payload.video_id,
+        )
         collection.status = "failed"
-        collection.error_message = "Erro inesperado durante a coleta."
+        collection.error_message = str(exc)[:500]
         db.commit()
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Erro inesperado durante a coleta.",
+            detail=f"Erro interno ao coletar comentários: {type(exc).__name__}: {exc}",
         ) from exc
 
 
@@ -407,17 +426,26 @@ async def collect_next_page(
         db.refresh(collection)
         return collection, next_page_token
     except httpx.HTTPStatusError as exc:
+        logger.exception(
+            "YouTube API erro HTTP %s na next-page collection_id=%s",
+            exc.response.status_code,
+            payload.collection_id,
+        )
         collection.status = "failed"
-        collection.error_message = "Erro na comunicação com o YouTube."
+        collection.error_message = str(exc)[:500]
         db.commit()
         raise _parse_youtube_error(exc) from exc
     except Exception as exc:
+        logger.exception(
+            "Erro inesperado em next-page collection_id=%s",
+            payload.collection_id,
+        )
         collection.status = "failed"
-        collection.error_message = "Erro inesperado durante a coleta."
+        collection.error_message = str(exc)[:500]
         db.commit()
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Erro inesperado durante a coleta.",
+            detail=f"Erro interno ao continuar coleta: {type(exc).__name__}: {exc}",
         ) from exc
 
 


### PR DESCRIPTION
## Summary

- Exceções logadas com `logger.exception()` antes de virar HTTPException
- `detail` inclui tipo e mensagem da exceção real (ex: `TimeoutError: timed out`)
- `error_message` na Collection salva `str(exc)` para diagnóstico
- `_parse_youtube_error` loga reason/message da API do YouTube
- Fallback HTTP usa 502 para erros de API externa
- `backend.md`: nova seção "Tratamento de erros" com regras obrigatórias

## Test plan

- [ ] 45 testes passando
- [ ] Simular erro de API → verificar mensagem descritiva na resposta

🤖 Generated with [Claude Code](https://claude.com/claude-code)