### PR TITLE
fix(ci): guard-main sempre roda (nunca skipped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,19 @@ on:
 
 jobs:
   guard-main:
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - name: Bloquear PR para main que não venha de dev
+      - name: Verificar origem do PR para main
         run: |
+          if [ "${{ github.event_name }}" != "pull_request" ] || [ "${{ github.base_ref }}" != "main" ]; then
+            echo "Não é PR para main — check ignorado."
+            exit 0
+          fi
           if [ "${{ github.head_ref }}" != "dev" ]; then
             echo "::error::PRs para main devem vir da branch dev, não de '${{ github.head_ref }}'."
             exit 1
           fi
-
-      - name: Impedir deleção da branch dev após merge
-        run: echo "⚠️ Não delete a branch dev após o merge — ela é permanente."
+          echo "PR de dev para main — permitido."
 
   backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Remover `if:` do job guard-main para que o check nunca fique "skipped"
- GitHub não enforça checks skipped no branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)