### PR TITLE
Merge dev into main — fix timeout Vercel

### DIFF
--- a/backend/services/youtube.py
+++ b/backend/services/youtube.py
@@ -10,7 +10,7 @@ async def fetch_comments_page(
     page_token: str | None = None,
 ) -> dict:
     params: dict = {
-        "part": "snippet,replies",
+        "part": "snippet",
         "videoId": video_id,
         "key": api_key,
         "maxResults": min(max_results, 100),
@@ -23,7 +23,7 @@ async def fetch_comments_page(
         response = await client.get(
             "https://www.googleapis.com/youtube/v3/commentThreads",
             params=params,
-            timeout=5.0,
+            timeout=4.0,
         )
         response.raise_for_status()
         return response.json()
@@ -35,7 +35,7 @@ async def fetch_video_info(video_id: str, api_key: str) -> dict | None:
         response = await client.get(
             "https://www.googleapis.com/youtube/v3/videos",
             params={"part": "snippet,statistics", "id": video_id, "key": api_key},
-            timeout=5.0,
+            timeout=4.0,
         )
         response.raise_for_status()
         items = response.json().get("items", [])
@@ -62,7 +62,7 @@ async def fetch_replies_page(
         response = await client.get(
             "https://www.googleapis.com/youtube/v3/comments",
             params=params,
-            timeout=5.0,
+            timeout=4.0,
         )
         response.raise_for_status()
         return response.json()
@@ -82,7 +82,7 @@ async def fetch_channels_info(
             response = await client.get(
                 "https://www.googleapis.com/youtube/v3/channels",
                 params={"part": "snippet", "id": ",".join(batch), "key": api_key},
-                timeout=5.0,
+                timeout=4.0,
             )
             response.raise_for_status()
             for item in response.json().get("items", []):


### PR DESCRIPTION
## Resumo

- Timeout httpx reduzido de 5s para 4s (margem para cold start Vercel)
- `commentThreads.list` usa `part=snippet` (replies movidas para enrich)

## Como testar

- [ ] Coleta em produção (Vercel): sem timeout/500
- [ ] Replies aparecem após fase de enrich