### PR TITLE
fix(collect): warmup para eliminar cold start Vercel + Neon

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,11 @@
 import os
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
+from sqlalchemy.orm import Session
 
+from database import get_db
 from routers import auth, collect, users
 
 # Em produção, definir CORS_ORIGINS no Vercel Dashboard:
@@ -28,5 +31,6 @@ app.include_router(collect.router)
 
 
 @app.get("/health")
-def health():
+def health(db: Session = Depends(get_db)):
+    db.execute(text("SELECT 1"))
     return {"status": "ok"}

--- a/frontend/src/api/collect.ts
+++ b/frontend/src/api/collect.ts
@@ -73,6 +73,14 @@ export interface ImportRequest {
 }
 
 export const collectApi = {
+  warmup: async () => {
+    try {
+      await fetch(`${API_URL}/health`);
+    } catch {
+      // best-effort
+    }
+  },
+
   start: (data: { video_id: string; api_key: string }, token: string) =>
     request<CollectionStarted>("/collect", { method: "POST", body: JSON.stringify(data) }, token),
 

--- a/frontend/src/pages/Collect/useCollect.ts
+++ b/frontend/src/pages/Collect/useCollect.ts
@@ -241,6 +241,7 @@ export function useCollect() {
       apiKeyRef.current = apiKey;
 
       try {
+        await collectApi.warmup();
         const result = await collectApi.start({ video_id: videoId, api_key: apiKey }, token);
         sessionStorage.setItem(STORAGE_KEY, result.collection_id);
         setState((s) => ({ ...s, active: result, loading: false }));
@@ -295,6 +296,7 @@ export function useCollect() {
 
       // Otherwise resume page collection
       try {
+        await collectApi.warmup();
         const next = await collectApi.nextPage(
           { collection_id: active.collection_id, api_key: apiKey },
           token


### PR DESCRIPTION
## Resumo

- `/health` agora executa `SELECT 1` no banco (acorda Neon scale-to-zero)
- Frontend chama `warmup()` antes de `start` e `resume` (acorda Vercel + Neon)
- Request real encontra tudo quente (~3-5s em vez de 10-14s)

## Como testar

- [ ] Em produção (Vercel): iniciar coleta após período de inatividade — não deve dar timeout
- [ ] Coleta contínua (next-page em loop): sem erros 500