### PR TITLE
docs(contributing): passo obrigatório de sync dev com main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,19 @@ Formato: `tipo(escopo): descrição curta no imperativo`
 - Usar **merge commit** (não squash, não rebase) — preserva histórico de feature
 - Deletar a branch de feature após o merge
 
-### 5. Release
+### 5. PR de `dev` para `main`
+
+Antes de criar o PR, **sincronizar `dev` com `main`**:
+
+```bash
+git checkout dev
+git pull origin main
+git push origin dev
+```
+
+Isso evita conflitos e garante que `dev` contém tudo que já está em `main`.
+
+### 6. Release
 
 Quando `dev` estiver pronto para produção:
 


### PR DESCRIPTION
## Resumo

- Novo passo 5 no CONTRIBUTING.md: sincronizar `dev` com `main` antes de criar PR `dev` → `main`

## Como testar

- [x] Verificar que o passo está documentado no CONTRIBUTING.md