### PR TITLE
docs: CODE_OF_CONDUCT, SECURITY e financiamento CNPq

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Código de Conduta
+
+## Nosso compromisso
+
+Este projeto faz parte de uma Iniciação Científica do DaVint Lab (PUCRS), financiada pelo CNPq. Todos os participantes — pesquisadores, orientadores e colaboradores — se comprometem a manter um ambiente respeitoso, inclusivo e produtivo.
+
+## Comportamento esperado
+
+- Tratar todos com respeito e profissionalismo
+- Aceitar críticas construtivas com maturidade
+- Focar nas contribuições técnicas e científicas
+- Dar crédito ao trabalho de outros colaboradores
+- Comunicar-se de forma clara e objetiva
+
+## Comportamento inaceitável
+
+- Linguagem ofensiva, discriminatória ou intimidadora
+- Assédio de qualquer forma
+- Publicação de informações privadas sem autorização
+- Uso indevido de dados de pesquisa ou credenciais
+
+## Escopo
+
+Este código se aplica a todas as interações no repositório (issues, PRs, comentários) e em comunicações relacionadas ao projeto.
+
+## Aplicação
+
+Violações podem ser reportadas diretamente ao coordenador do projeto. Todas as denúncias serão tratadas com confidencialidade.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plataforma de Análise de Comentários e Detecção de Bots no YouTube
 
-Sistema de coleta, limpeza, anotação e análise de comentários do YouTube para detecção de bots, desenvolvido no **DaVint Lab / PUCRS** como projeto de Iniciação Científica.
+Sistema de coleta, limpeza, anotação e análise de comentários do YouTube para detecção de bots, desenvolvido no **DaVint Lab / PUCRS** como projeto de Iniciação Científica financiado pelo **CNPq**.
 
 ## Visão geral
 
@@ -127,6 +127,10 @@ O CI executa automaticamente em todo push e PR:
 
 - **Backend:** Ruff · Bandit · pip-audit · Pytest (≥ 80% cobertura)
 - **Frontend:** ESLint · Prettier · tsc · npm audit
+
+## Financiamento
+
+Este projeto é financiado pelo **CNPq** (Conselho Nacional de Desenvolvimento Científico e Tecnológico) como bolsa de Iniciação Científica, vinculada ao **DaVint Lab / PUCRS**.
 
 ## Licença
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Política de Segurança
+
+## Reportar vulnerabilidades
+
+Se você encontrar uma vulnerabilidade de segurança neste projeto, **não abra uma issue pública**. Reporte diretamente ao coordenador do projeto via e-mail.
+
+## Medidas adotadas
+
+- Credenciais e segredos nunca são commitados no repositório
+- Análise estática de segurança executada automaticamente em todo push (CI)
+- Auditoria de dependências para vulnerabilidades conhecidas (Python e JavaScript)
+- Atualizações automáticas de segurança via Dependabot
+- HTTPS obrigatório em produção
+
+## Versões suportadas
+
+| Versão | Suporte |
+|---|---|
+| Branch `main` | Ativa |
+| Branch `dev` | Ativa |
+| Branches de feature | Sem suporte de segurança |


### PR DESCRIPTION
## Resumo

- CODE_OF_CONDUCT.md para contexto de IC / DaVint Lab / CNPq
- SECURITY.md com política de reporte e versões suportadas (main + dev)
- README.md: menção ao CNPq na descrição e nova seção Financiamento

## Como testar

- [x] Verificar que CODE_OF_CONDUCT e Security policy aparecem na sidebar do repositório
- [x] README mostra seção Financiamento com menção ao CNPq