### PR TITLE
fix(frontend): avisos de API key, disclaimer e confirmação de desativar

### DIFF
--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -22,7 +22,7 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-davint-50 via-white to-davint-50 p-6">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-davint-50 via-white to-davint-50 p-6">
       <div className="bg-white rounded-xl shadow-xl px-9 py-10 w-full max-w-[420px]">
         <div className="flex flex-col items-center text-center mb-8 gap-2.5">
           <img src="/davint-logo.png" alt="DaVint Lab" className="h-12 w-auto mb-1" />

--- a/frontend/src/pages/Collect/CollectPage.tsx
+++ b/frontend/src/pages/Collect/CollectPage.tsx
@@ -259,6 +259,39 @@ export function CollectPage() {
                 },
               ]}
             />
+            <div className="flex items-start gap-2.5 p-4 bg-yellow-50 border border-yellow-200 rounded-xl mb-6">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className="w-5 h-5 text-yellow-500 shrink-0 mt-0.5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div className="text-sm text-yellow-700">
+                <p className="font-semibold">
+                  Você precisa de uma API key pessoal e intransferível
+                </p>
+                <p className="mt-1 text-xs">
+                  Crie sua chave em{" "}
+                  <a
+                    href="https://console.cloud.google.com/apis/credentials"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline font-medium"
+                  >
+                    Google Cloud Console
+                  </a>{" "}
+                  com a <strong>YouTube Data API v3</strong> habilitada. Cada pesquisador deve ter
+                  sua própria chave — não compartilhe entre colegas. A chave não é armazenada pela
+                  plataforma.
+                </p>
+              </div>
+            </div>
             <div className="bg-white rounded-xl border border-gray-200 p-6 mb-8">
               <form onSubmit={handleSubmit} className="flex flex-col gap-5">
                 <div className="form-group">

--- a/frontend/src/pages/Users/CreateUserModal.tsx
+++ b/frontend/src/pages/Users/CreateUserModal.tsx
@@ -100,6 +100,39 @@ export function CreateUserModal({ onClose, onCreate }: Props) {
             </div>
 
             {error && <div className="alert alert-error mt-4">{error}</div>}
+
+            <div className="flex items-start gap-2.5 p-3 bg-yellow-50 border border-yellow-200 rounded-lg mt-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className="w-4 h-4 text-yellow-500 shrink-0 mt-0.5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <div className="text-xs text-yellow-700">
+                <p className="font-semibold mb-1">
+                  Cada anotador precisa de sua própria API key do YouTube
+                </p>
+                <p>
+                  Instrua o pesquisador a criar uma chave em{" "}
+                  <a
+                    href="https://console.cloud.google.com/apis/credentials"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline font-medium"
+                  >
+                    Google Cloud Console
+                  </a>{" "}
+                  com a YouTube Data API v3 habilitada. A chave é pessoal e intransferível — não
+                  deve ser compartilhada entre pesquisadores.
+                </p>
+              </div>
+            </div>
           </div>
 
           <div className="flex justify-end gap-2.5 px-6 py-5 border-t border-gray-200 mt-6">

--- a/frontend/src/pages/Users/UsersPage.tsx
+++ b/frontend/src/pages/Users/UsersPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { usersApi } from "../../api/users";
 import { PageHeader } from "../../components/PageHeader";
+import { StepsCard } from "../../components/StepsCard";
 import { useAuthContext } from "../../contexts/AuthContext";
 import { ChangePasswordModal } from "../Home/ChangePasswordModal";
 import { CreateUserModal } from "./CreateUserModal";
@@ -50,6 +51,56 @@ export function UsersPage() {
 
       {/* Conteúdo */}
       <main className="flex-1 px-8 py-9 max-w-6xl w-full mx-auto">
+        <StepsCard
+          title="Gestão de usuários"
+          steps={[
+            {
+              label: "Crie contas para os anotadores",
+              description:
+                "Cada pesquisador recebe um usuário com nome, username e senha. O papel padrão é 'user' (anotador).",
+            },
+            {
+              label: "Anotadores acessam a plataforma com suas credenciais",
+              description:
+                "Eles podem coletar comentários, anotar e visualizar dados compartilhados.",
+            },
+            {
+              label: "Desative contas de quem saiu do laboratório",
+              description:
+                "Soft-delete preserva as anotações feitas. Contas podem ser reativadas a qualquer momento.",
+            },
+          ]}
+        />
+        <div className="flex items-start gap-2.5 p-4 bg-yellow-50 border border-yellow-200 rounded-xl mb-6">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-5 h-5 text-yellow-500 shrink-0 mt-0.5"
+          >
+            <path
+              fillRule="evenodd"
+              d="M6.701 2.25c.577-1 2.02-1 2.598 0l5.196 9a1.5 1.5 0 0 1-1.299 2.25H2.804a1.5 1.5 0 0 1-1.3-2.25l5.197-9ZM8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="text-sm text-yellow-700">
+            <p className="font-semibold">Cada anotador precisa de sua própria API key do YouTube</p>
+            <p className="mt-1 text-xs">
+              Antes de criar a conta, instrua o pesquisador a gerar uma chave em{" "}
+              <a
+                href="https://console.cloud.google.com/apis/credentials"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline font-medium"
+              >
+                Google Cloud Console
+              </a>{" "}
+              com a <strong>YouTube Data API v3</strong> habilitada. A chave é pessoal e
+              intransferível — não deve ser compartilhada entre pesquisadores.
+            </p>
+          </div>
+        </div>
         <div className="bg-white rounded-xl shadow-md overflow-hidden">
           <div className="flex items-center justify-between px-7 py-6 border-b border-gray-200">
             <div>
@@ -143,7 +194,15 @@ export function UsersPage() {
                               <button
                                 className="btn btn-danger"
                                 disabled={deactivatingId === u.id}
-                                onClick={() => void handleDeactivate(u.id)}
+                                onClick={() => {
+                                  if (
+                                    window.confirm(
+                                      `Desativar "${u.name}" (@${u.username})?\n\nO usuário não poderá mais acessar a plataforma. As anotações feitas serão preservadas. Você pode reativar a conta a qualquer momento.`
+                                    )
+                                  ) {
+                                    void handleDeactivate(u.id);
+                                  }
+                                }}
                               >
                                 {deactivatingId === u.id ? "Desativando…" : "Desativar"}
                               </button>


### PR DESCRIPTION
## Resumo

- LoginPage: disclaimer abaixo do card com DaVint Lab (Data Visualization and Interaction), CNPq e Claude
- CollectPage: banner amarelo "API key pessoal e intransferível" com link para Google Cloud Console
- UsersPage: StepsCard de gestão de usuários + banner amarelo de API key
- CreateUserModal: alert de API key pessoal e intransferível
- Confirmação (window.confirm) antes de desativar usuário

## Como testar

- [ ] Login: disclaimer visível abaixo do card
- [ ] Coleta: banner amarelo visível entre steps e formulário
- [ ] Usuários: StepsCard + banner amarelo visíveis
- [ ] Criar usuário: alert amarelo no modal
- [ ] Desativar usuário: window.confirm com mensagem explicativa