### PR TITLE
fix(infra): corrigir vercel.json conflito functions/builds

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -2,15 +2,10 @@
   "version": 2,
   "functions": {
     "main.py": {
+      "runtime": "@vercel/python",
       "maxDuration": 60
     }
   },
-  "builds": [
-    {
-      "src": "main.py",
-      "use": "@vercel/python"
-    }
-  ],
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
Remove `builds` e migra para `functions` com `runtime`, conforme exigência do Vercel.