### PR TITLE
feat(annotate): ordenar pendentes primeiro, filtrar e navegar por página

### DIFF
--- a/backend/routers/annotate.py
+++ b/backend/routers/annotate.py
@@ -42,6 +42,8 @@ def list_users_endpoint(
     dataset_id: uuid.UUID,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
+    pending_first: bool = Query(default=False),
+    only_pending: bool = Query(default=False),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -52,6 +54,8 @@ def list_users_endpoint(
         is_admin=current_user.role == "admin",
         page=page,
         page_size=page_size,
+        pending_first=pending_first,
+        only_pending=only_pending,
     )
 
 

--- a/backend/services/annotate.py
+++ b/backend/services/annotate.py
@@ -29,6 +29,8 @@ def list_dataset_users(
     is_admin: bool = False,
     page: int = 1,
     page_size: int = 20,
+    pending_first: bool = False,
+    only_pending: bool = False,
 ) -> dict:
     dataset = db.query(Dataset).filter(Dataset.id == dataset_id).first()
     if dataset is None:
@@ -36,27 +38,78 @@ def list_dataset_users(
 
     collection_id = dataset.collection_id
 
-    # Total de entries (1 query COUNT, sem carregar objetos)
-    total_users = (
-        db.query(func.count(DatasetEntry.id))
-        .filter(DatasetEntry.dataset_id == dataset_id)
-        .scalar()
+    # Subquery: comment_count por autor no dataset
+    comment_count_sub = (
+        db.query(
+            Comment.author_channel_id,
+            func.count(Comment.id).label("cc"),
+        )
+        .filter(Comment.collection_id == collection_id)
+        .group_by(Comment.author_channel_id)
+        .subquery()
     )
 
-    # Página de entries (LIMIT/OFFSET no banco)
+    # Subquery: annotated_count por autor
+    if is_admin:
+        ann_sub = (
+            db.query(
+                Comment.author_channel_id,
+                func.count(func.distinct(Annotation.comment_id)).label("ac"),
+            )
+            .join(Annotation, Annotation.comment_id == Comment.id)
+            .filter(Comment.collection_id == collection_id)
+            .group_by(Comment.author_channel_id)
+            .subquery()
+        )
+    else:
+        ann_sub = (
+            db.query(
+                Comment.author_channel_id,
+                func.count(Annotation.id).label("ac"),
+            )
+            .join(Annotation, Annotation.comment_id == Comment.id)
+            .filter(
+                Comment.collection_id == collection_id,
+                Annotation.annotator_id == annotator_id,
+            )
+            .group_by(Comment.author_channel_id)
+            .subquery()
+        )
+
+    # Query base com LEFT JOINs para contagens
+    cc_col = func.coalesce(comment_count_sub.c.cc, 0)
+    ac_col = func.coalesce(ann_sub.c.ac, 0)
+    pending_col = (cc_col - ac_col).label("pending")
+
+    base_query = (
+        db.query(DatasetEntry, cc_col.label("cc"), ac_col.label("ac"), pending_col)
+        .outerjoin(
+            comment_count_sub,
+            comment_count_sub.c.author_channel_id == DatasetEntry.author_channel_id,
+        )
+        .outerjoin(
+            ann_sub,
+            ann_sub.c.author_channel_id == DatasetEntry.author_channel_id,
+        )
+        .filter(DatasetEntry.dataset_id == dataset_id)
+    )
+
+    if only_pending:
+        base_query = base_query.filter(pending_col > 0)
+
+    # Total filtrado
+    total_users = base_query.count()
+
+    # Ordenação
+    if pending_first:
+        order = [pending_col.desc(), DatasetEntry.author_display_name]
+    else:
+        order = [DatasetEntry.author_display_name]
+
     offset = (page - 1) * page_size
-    entries = (
-        db.query(DatasetEntry)
-        .filter(DatasetEntry.dataset_id == dataset_id)
-        .order_by(DatasetEntry.author_display_name)
-        .offset(offset)
-        .limit(page_size)
-        .all()
-    )
+    rows = base_query.order_by(*order).offset(offset).limit(page_size).all()
 
-    page_author_ids = [e.author_channel_id for e in entries]
-
-    # Totais globais (todos os autores do dataset, não só da página)
+    # Totais globais (sem filtro only_pending)
     all_author_ids_sub = (
         db.query(DatasetEntry.author_channel_id)
         .filter(DatasetEntry.dataset_id == dataset_id)
@@ -94,63 +147,9 @@ def list_dataset_users(
             .scalar()
         ) or 0
 
-    if not page_author_ids:
-        return {
-            "dataset_id": dataset.id,
-            "dataset_name": dataset.name,
-            "total_users": total_users,
-            "total_comments": total_comments,
-            "annotated_comments_by_me": total_annotated,
-            "page": page,
-            "page_size": page_size,
-            "total_pages": _total_pages(total_users, page_size),
-            "items": [],
-        }
-
-    # Contagens apenas para os autores da página
-    comment_counts = (
-        db.query(Comment.author_channel_id, func.count(Comment.id))
-        .filter(
-            Comment.collection_id == collection_id,
-            Comment.author_channel_id.in_(page_author_ids),
-        )
-        .group_by(Comment.author_channel_id)
-        .all()
-    )
-    counts_map = dict(comment_counts)
-
-    if is_admin:
-        ann_counts = (
-            db.query(
-                Comment.author_channel_id,
-                func.count(func.distinct(Annotation.comment_id)),
-            )
-            .join(Annotation, Annotation.comment_id == Comment.id)
-            .filter(
-                Comment.collection_id == collection_id,
-                Comment.author_channel_id.in_(page_author_ids),
-            )
-            .group_by(Comment.author_channel_id)
-            .all()
-        )
-    else:
-        ann_counts = (
-            db.query(Comment.author_channel_id, func.count(Annotation.id))
-            .join(Annotation, Annotation.comment_id == Comment.id)
-            .filter(
-                Comment.collection_id == collection_id,
-                Comment.author_channel_id.in_(page_author_ids),
-                Annotation.annotator_id == annotator_id,
-            )
-            .group_by(Comment.author_channel_id)
-            .all()
-        )
-    ann_map = dict(ann_counts)
-
+    # Montar items a partir das rows (contagens já vêm da query)
     items = []
-    for entry in entries:
-        cc = counts_map.get(entry.author_channel_id, 0)
-        ac = ann_map.get(entry.author_channel_id, 0)
+    for entry, cc, ac, _pending in rows:
         items.append(
             {
                 "entry_id": entry.id,

--- a/frontend/src/api/annotate.ts
+++ b/frontend/src/api/annotate.ts
@@ -92,12 +92,19 @@ export interface AnnotatorProgress {
 // ─── API ────────────────────────────────────────────────────────────────────
 
 export const annotateApi = {
-  listUsers: (datasetId: string, token: string, page = 1, pageSize = 20) =>
-    request<DatasetUsersResponse>(
-      `/annotate/users?dataset_id=${datasetId}&page=${page}&page_size=${pageSize}`,
-      {},
-      token
-    ),
+  listUsers: (
+    datasetId: string,
+    token: string,
+    opts?: { page?: number; pageSize?: number; pendingFirst?: boolean; onlyPending?: boolean }
+  ) => {
+    const qs = new URLSearchParams();
+    qs.set("dataset_id", datasetId);
+    qs.set("page", String(opts?.page ?? 1));
+    qs.set("page_size", String(opts?.pageSize ?? 20));
+    if (opts?.pendingFirst) qs.set("pending_first", "true");
+    if (opts?.onlyPending) qs.set("only_pending", "true");
+    return request<DatasetUsersResponse>(`/annotate/users?${qs}`, {}, token);
+  },
 
   getComments: (entryId: string, token: string) =>
     request<UserCommentsResponse>(`/annotate/comments/${entryId}`, {}, token),

--- a/frontend/src/hooks/useAnnotate.ts
+++ b/frontend/src/hooks/useAnnotate.ts
@@ -41,11 +41,14 @@ export function useAnnotate() {
   }, []);
 
   const fetchDatasetUsers = useCallback(
-    async (datasetId: string, page = 1, pageSize = 20) => {
+    async (
+      datasetId: string,
+      opts?: { page?: number; pageSize?: number; pendingFirst?: boolean; onlyPending?: boolean }
+    ) => {
       if (!token) return;
       setState((s) => ({ ...s, loading: true, error: null }));
       try {
-        const result = await annotateApi.listUsers(datasetId, token, page, pageSize);
+        const result = await annotateApi.listUsers(datasetId, token, opts);
         setState((s) => ({ ...s, loading: false, datasetUsers: result, userComments: null }));
         return result;
       } catch (err) {

--- a/frontend/src/pages/Annotate/AnnotatePage.tsx
+++ b/frontend/src/pages/Annotate/AnnotatePage.tsx
@@ -18,6 +18,9 @@ export function AnnotatePage() {
   const [selectedDatasetId, setSelectedDatasetId] = useState("");
   const [toast, setToast] = useState<string | null>(null);
   const [usersPage, setUsersPage] = useState(1);
+  const [pendingFirst, setPendingFirst] = useState(true);
+  const [onlyPending, setOnlyPending] = useState(false);
+  const [pageInput, setPageInput] = useState("1");
   const USERS_PER_PAGE = 20;
 
   const {
@@ -58,27 +61,80 @@ export function AnnotatePage() {
     }
   }, [isAdmin, fetchProgress, fetchAllProgress]);
 
+  // ─── Derived ────────────────────────────────────────────────────────
+  const datasetProgress = progress.find((p) => p.dataset_id === selectedDatasetId);
+  const globalPercent = datasetProgress ? datasetProgress.percent_complete : 0;
+  const totalUsersPages = datasetUsers?.total_pages ?? 0;
+
+  // ─── Helpers ─────────────────────────────────────────────────────────
+  const fetchOpts = useCallback(
+    (page: number) => ({
+      page,
+      pageSize: USERS_PER_PAGE,
+      pendingFirst,
+      onlyPending,
+    }),
+    [pendingFirst, onlyPending]
+  );
+
   // ─── Handlers ───────────────────────────────────────────────────────
   const handleSelectDataset = useCallback(
     (id: string) => {
       setSelectedDatasetId(id);
       setUsersPage(1);
+      setPageInput("1");
       if (id) {
-        fetchDatasetUsers(id, 1, USERS_PER_PAGE);
+        fetchDatasetUsers(id, fetchOpts(1));
       }
     },
-    [fetchDatasetUsers]
+    [fetchDatasetUsers, fetchOpts]
   );
 
   const handlePageChange = useCallback(
     (newPage: number) => {
       setUsersPage(newPage);
+      setPageInput(String(newPage));
       if (selectedDatasetId) {
-        fetchDatasetUsers(selectedDatasetId, newPage, USERS_PER_PAGE);
+        fetchDatasetUsers(selectedDatasetId, fetchOpts(newPage));
       }
     },
-    [selectedDatasetId, fetchDatasetUsers]
+    [selectedDatasetId, fetchDatasetUsers, fetchOpts]
   );
+
+  const handlePageInputSubmit = useCallback(() => {
+    const p = Math.max(1, Math.min(parseInt(pageInput, 10) || 1, totalUsersPages || 1));
+    handlePageChange(p);
+  }, [pageInput, totalUsersPages, handlePageChange]);
+
+  const handleTogglePendingFirst = useCallback(() => {
+    const next = !pendingFirst;
+    setPendingFirst(next);
+    setUsersPage(1);
+    setPageInput("1");
+    if (selectedDatasetId) {
+      fetchDatasetUsers(selectedDatasetId, {
+        page: 1,
+        pageSize: USERS_PER_PAGE,
+        pendingFirst: next,
+        onlyPending,
+      });
+    }
+  }, [pendingFirst, onlyPending, selectedDatasetId, fetchDatasetUsers]);
+
+  const handleToggleOnlyPending = useCallback(() => {
+    const next = !onlyPending;
+    setOnlyPending(next);
+    setUsersPage(1);
+    setPageInput("1");
+    if (selectedDatasetId) {
+      fetchDatasetUsers(selectedDatasetId, {
+        page: 1,
+        pageSize: USERS_PER_PAGE,
+        pendingFirst,
+        onlyPending: next,
+      });
+    }
+  }, [onlyPending, pendingFirst, selectedDatasetId, fetchDatasetUsers]);
 
   const handleSelectUser = useCallback(
     (entryId: string) => {
@@ -102,9 +158,9 @@ export function AnnotatePage() {
 
   const handleBackToUsers = useCallback(() => {
     if (selectedDatasetId) {
-      fetchDatasetUsers(selectedDatasetId, usersPage, USERS_PER_PAGE);
+      fetchDatasetUsers(selectedDatasetId, fetchOpts(usersPage));
     }
-  }, [selectedDatasetId, usersPage, fetchDatasetUsers]);
+  }, [selectedDatasetId, usersPage, fetchDatasetUsers, fetchOpts]);
 
   const handleImport = useCallback(
     (e: FormEvent) => {
@@ -147,12 +203,6 @@ export function AnnotatePage() {
     },
     [importFile, importAnnotations, fetchProgress]
   );
-
-  // ─── Derived ────────────────────────────────────────────────────────
-  const datasetProgress = progress.find((p) => p.dataset_id === selectedDatasetId);
-  const globalPercent = datasetProgress ? datasetProgress.percent_complete : 0;
-
-  const totalUsersPages = datasetUsers?.total_pages ?? 0;
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
@@ -352,6 +402,51 @@ export function AnnotatePage() {
                       label={`${globalPercent}% — ${datasetProgress.bots} bots, ${datasetProgress.humans} humanos`}
                       size="sm"
                     />
+                  </div>
+                )}
+
+                {/* Filtros e navegação */}
+                {datasetUsers && (
+                  <div className="flex flex-wrap items-center gap-4 mb-4">
+                    {!isAdmin && (
+                      <>
+                        <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="rounded border-gray-300 text-davint-400 focus:ring-davint-400"
+                            checked={pendingFirst}
+                            onChange={handleTogglePendingFirst}
+                          />
+                          Pendentes primeiro
+                        </label>
+                        <label className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="rounded border-gray-300 text-davint-400 focus:ring-davint-400"
+                            checked={onlyPending}
+                            onChange={handleToggleOnlyPending}
+                          />
+                          Apenas pendentes
+                        </label>
+                      </>
+                    )}
+
+                    {totalUsersPages > 1 && (
+                      <div className="flex items-center gap-1.5 ml-auto">
+                        <span className="text-xs text-gray-500">Página</span>
+                        <input
+                          type="number"
+                          min={1}
+                          max={totalUsersPages}
+                          value={pageInput}
+                          onChange={(e) => setPageInput(e.target.value)}
+                          onKeyDown={(e) => e.key === "Enter" && handlePageInputSubmit()}
+                          onBlur={handlePageInputSubmit}
+                          className="w-14 px-2 py-1 text-xs text-center border border-gray-200 rounded focus:border-davint-400 focus:ring-1 focus:ring-davint-400 outline-none"
+                        />
+                        <span className="text-xs text-gray-400">de {totalUsersPages}</span>
+                      </div>
+                    )}
                   </div>
                 )}
 


### PR DESCRIPTION
## Resumo

- **Pendentes primeiro**: checkbox que ordena usuários com comentários não anotados no topo (ORDER BY pending DESC no SQL)
- **Apenas pendentes**: checkbox que esconde usuários já concluídos (WHERE pending > 0 no SQL)
- **Input de página**: campo numérico para ir direto a qualquer página (Enter ou blur aplica)
- Ordenação e filtro no SQL via subqueries + LEFT JOIN — sem queries extras

## Como testar

- [x] 142 testes passando (0 falhas)
- [x] `ruff check` + `ruff format --check` limpos
- [x] `tsc --noEmit` + `prettier --check` sem erros
- [ ] Selecionar dataset com anotações parciais e verificar que pendentes aparecem primeiro
- [ ] Marcar "Apenas pendentes" e confirmar que concluídos somem da lista
- [ ] Digitar número de página e pressionar Enter — confirmar navegação direta
- [ ] Admin não vê checkboxes de filtro (modo visualização)

🤖 Generated with [Claude Code](https://claude.com/claude-code)