### PR TITLE
feat(data): catálogo centralizado de dados (US-07)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from database import get_db
-from routers import annotate, auth, clean, collect, review, seed, users
+from routers import annotate, auth, clean, collect, data, review, seed, users
 
 # Em produção, definir CORS_ORIGINS no Vercel Dashboard:
 #   CORS_ORIGINS=https://seu-frontend.vercel.app
@@ -29,6 +29,7 @@ app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(collect.router)
 app.include_router(clean.router)
+app.include_router(data.router)
 app.include_router(annotate.router)
 app.include_router(review.router)
 app.include_router(seed.router)

--- a/backend/routers/data.py
+++ b/backend/routers/data.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models.user import User
+from schemas.data import (
+    DataAnnotationProgress,
+    DataCollection,
+    DataDataset,
+    DataSummary,
+)
+from services.auth import get_current_user
+from services.data import (
+    get_annotation_progress,
+    get_summary,
+    list_all_collections,
+    list_all_datasets,
+)
+
+router = APIRouter(prefix="/data", tags=["data"])
+
+
+@router.get("/summary", response_model=DataSummary)
+def summary_endpoint(
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    return get_summary(db)
+
+
+@router.get("/collections", response_model=list[DataCollection])
+def collections_endpoint(
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    return list_all_collections(db)
+
+
+@router.get("/datasets", response_model=list[DataDataset])
+def datasets_endpoint(
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    return list_all_datasets(db)
+
+
+@router.get("/annotations", response_model=list[DataAnnotationProgress])
+def annotations_endpoint(
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    return get_annotation_progress(db)

--- a/backend/schemas/data.py
+++ b/backend/schemas/data.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DataSummary(BaseModel):
+    collections_count: int
+    comments_count: int
+    datasets_count: int
+    annotations_count: int
+    estimated_size_mb: float
+
+
+class DataCollection(BaseModel):
+    collection_id: uuid.UUID
+    video_id: str
+    video_title: str | None = None
+    total_comments: int | None = None
+    status: str
+    enrich_status: str | None = None
+    channel_dates_failed: bool | None = None
+    total_users: int
+    collected_by: str
+    created_at: datetime
+    completed_at: datetime | None = None
+    duration_seconds: int | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataDataset(BaseModel):
+    dataset_id: uuid.UUID
+    name: str
+    collection_id: uuid.UUID
+    video_id: str
+    criteria: list[str]
+    total_users_original: int
+    total_selected: int
+    total_comments: int
+    created_by: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataAnnotationProgress(BaseModel):
+    dataset_id: uuid.UUID
+    dataset_name: str
+    total: int
+    annotated: int
+    pending: int
+    conflicts: int
+    conflicts_resolved: int
+    annotators_count: int
+    bots_users: int
+    bots_comments: int

--- a/backend/services/data.py
+++ b/backend/services/data.py
@@ -1,0 +1,382 @@
+"""Serviço da US-07 — catálogo centralizado de dados."""
+
+import logging
+import uuid
+from collections import defaultdict
+
+from sqlalchemy import func, text
+from sqlalchemy.orm import Session
+
+from models.annotation import Annotation, AnnotationConflict
+from models.collection import Collection, Comment
+from models.dataset import Dataset, DatasetEntry
+from models.user import User
+
+logger = logging.getLogger(__name__)
+
+# Tabelas cujo tamanho é somado para estimar uso do banco
+_SIZE_TABLES = (
+    "collections",
+    "comments",
+    "datasets",
+    "dataset_entries",
+    "annotations",
+    "annotation_conflicts",
+    "resolutions",
+    "users",
+)
+
+
+def get_summary(db: Session) -> dict:
+    """Contagem de registros + estimativa de tamanho via pg_total_relation_size."""
+    collections_count = db.query(func.count(Collection.id)).scalar() or 0
+    comments_count = db.query(func.count(Comment.id)).scalar() or 0
+    datasets_count = db.query(func.count(Dataset.id)).scalar() or 0
+    annotations_count = db.query(func.count(Annotation.id)).scalar() or 0
+
+    # Estimativa de tamanho em MB (dados + índices + TOAST)
+    total_bytes = 0
+    for table in _SIZE_TABLES:
+        try:
+            row = db.execute(
+                text("SELECT pg_total_relation_size(:t)"),
+                {"t": table},
+            ).scalar()
+            total_bytes += row or 0
+        except Exception:
+            logger.debug("pg_total_relation_size falhou para %s", table)
+
+    estimated_size_mb = round(total_bytes / (1024 * 1024), 2)
+
+    return {
+        "collections_count": collections_count,
+        "comments_count": comments_count,
+        "datasets_count": datasets_count,
+        "annotations_count": annotations_count,
+        "estimated_size_mb": estimated_size_mb,
+    }
+
+
+def list_all_collections(db: Session) -> list[dict]:
+    """Todas as coletas com nome do coletor, ordenadas por data decrescente."""
+    collections = db.query(Collection).order_by(Collection.created_at.desc()).all()
+
+    if not collections:
+        return []
+
+    # Batch load users
+    user_ids = {c.collected_by for c in collections}
+    users = db.query(User).filter(User.id.in_(user_ids)).all()
+    user_map = {u.id: u for u in users}
+
+    # Batch: autores distintos por coleta
+    col_ids = [c.id for c in collections]
+    user_counts = (
+        db.query(
+            Comment.collection_id,
+            func.count(func.distinct(Comment.author_channel_id)),
+        )
+        .filter(Comment.collection_id.in_(col_ids))
+        .group_by(Comment.collection_id)
+        .all()
+    )
+    users_by_col = {row[0]: row[1] for row in user_counts}
+
+    return [
+        {
+            "collection_id": c.id,
+            "video_id": c.video_id,
+            "video_title": c.video_title,
+            "total_comments": c.total_comments,
+            "total_users": users_by_col.get(c.id, 0),
+            "status": c.status,
+            "enrich_status": c.enrich_status,
+            "channel_dates_failed": c.channel_dates_failed,
+            "collected_by": user_map[c.collected_by].username
+            if c.collected_by in user_map
+            else "",
+            "created_at": c.created_at,
+            "completed_at": c.completed_at,
+            "duration_seconds": c.duration_seconds,
+        }
+        for c in collections
+    ]
+
+
+def list_all_datasets(db: Session) -> list[dict]:
+    """Todos os datasets limpos, ordenados por data decrescente.
+
+    Otimizado: 5 queries constantes independente do número de datasets.
+    """
+    datasets = db.query(Dataset).order_by(Dataset.created_at.desc()).all()
+
+    if not datasets:
+        return []
+
+    ds_ids = [ds.id for ds in datasets]
+
+    # Batch load collections e users
+    collection_ids = {ds.collection_id for ds in datasets}
+    collections = db.query(Collection).filter(Collection.id.in_(collection_ids)).all()
+    col_map = {c.id: c for c in collections}
+
+    user_ids = {ds.created_by for ds in datasets}
+    users = db.query(User).filter(User.id.in_(user_ids)).all()
+    user_map = {u.id: u for u in users}
+
+    # Batch: entries por dataset → author_ids agrupados
+    all_entries = (
+        db.query(
+            DatasetEntry.dataset_id,
+            DatasetEntry.author_channel_id,
+        )
+        .filter(DatasetEntry.dataset_id.in_(ds_ids))
+        .all()
+    )
+    authors_by_ds: dict[uuid.UUID, list[str]] = defaultdict(list)
+    for dataset_id, author_channel_id in all_entries:
+        authors_by_ds[dataset_id].append(author_channel_id)
+
+    # Batch: contagem de comentários por (collection_id, author_channel_id)
+    # Coletamos todos os pares (collection_id, author_channel_id) necessários
+    all_pairs: set[tuple[uuid.UUID, str]] = set()
+    for ds in datasets:
+        for author_id in authors_by_ds.get(ds.id, []):
+            all_pairs.add((ds.collection_id, author_id))
+
+    # Uma query para contar todos os comentários de todos os pares
+    comments_count_map: dict[tuple[uuid.UUID, str], int] = {}
+    if all_pairs:
+        # Agrupar por collection_id para queries menores
+        by_col: dict[uuid.UUID, list[str]] = defaultdict(list)
+        for col_id, author_id in all_pairs:
+            by_col[col_id].append(author_id)
+
+        for col_id, author_list in by_col.items():
+            rows = (
+                db.query(
+                    Comment.author_channel_id,
+                    func.count(Comment.id),
+                )
+                .filter(
+                    Comment.collection_id == col_id,
+                    Comment.author_channel_id.in_(author_list),
+                )
+                .group_by(Comment.author_channel_id)
+                .all()
+            )
+            for author_id, cnt in rows:
+                comments_count_map[(col_id, author_id)] = cnt
+
+    results = []
+    for ds in datasets:
+        ds_authors = authors_by_ds.get(ds.id, [])
+        total_comments = sum(
+            comments_count_map.get((ds.collection_id, a), 0) for a in ds_authors
+        )
+
+        results.append(
+            {
+                "dataset_id": ds.id,
+                "name": ds.name,
+                "collection_id": ds.collection_id,
+                "video_id": col_map[ds.collection_id].video_id
+                if ds.collection_id in col_map
+                else "",
+                "criteria": ds.criteria_applied,
+                "total_users_original": ds.total_users_original,
+                "total_selected": ds.total_users_selected,
+                "total_comments": total_comments,
+                "created_by": user_map[ds.created_by].username
+                if ds.created_by in user_map
+                else "",
+                "created_at": ds.created_at,
+            }
+        )
+
+    return results
+
+
+def get_annotation_progress(db: Session) -> list[dict]:
+    """Progresso de anotação por dataset.
+
+    Otimizado: número constante de queries independente do número de datasets
+    e comentários. Sem loops N+1.
+    """
+    datasets = db.query(Dataset).order_by(Dataset.created_at.desc()).all()
+
+    if not datasets:
+        return []
+
+    ds_ids = [ds.id for ds in datasets]
+
+    # 1) Batch: entries → authors por dataset
+    all_entries = (
+        db.query(DatasetEntry.dataset_id, DatasetEntry.author_channel_id)
+        .filter(DatasetEntry.dataset_id.in_(ds_ids))
+        .all()
+    )
+    authors_by_ds: dict[uuid.UUID, list[str]] = defaultdict(list)
+    for dataset_id, author_channel_id in all_entries:
+        authors_by_ds[dataset_id].append(author_channel_id)
+
+    # 2) Batch: todos os comentários relevantes (id, collection_id, author_channel_id)
+    #    Monta pares (collection_id, [author_ids]) para buscar de uma vez
+    col_authors: dict[uuid.UUID, set[str]] = defaultdict(set)
+    ds_col_map = {ds.id: ds.collection_id for ds in datasets}
+    for ds in datasets:
+        for author_id in authors_by_ds.get(ds.id, []):
+            col_authors[ds.collection_id].add(author_id)
+
+    # Buscar todos os comentários necessários em batch por collection
+    # comment_id → (collection_id, author_channel_id)
+    comment_info: dict[uuid.UUID, tuple[uuid.UUID, str]] = {}
+    # (collection_id, author_channel_id) → [comment_ids]
+    comments_by_col_author: dict[tuple[uuid.UUID, str], list[uuid.UUID]] = defaultdict(
+        list
+    )
+
+    for col_id, author_set in col_authors.items():
+        if not author_set:
+            continue
+        rows = (
+            db.query(Comment.id, Comment.collection_id, Comment.author_channel_id)
+            .filter(
+                Comment.collection_id == col_id,
+                Comment.author_channel_id.in_(list(author_set)),
+            )
+            .all()
+        )
+        for cid, c_col_id, c_author_id in rows:
+            comment_info[cid] = (c_col_id, c_author_id)
+            comments_by_col_author[(c_col_id, c_author_id)].append(cid)
+
+    # Coletar todos os comment_ids relevantes
+    all_comment_ids = list(comment_info.keys())
+
+    # 3) Batch: anotações (comment_id, annotator_id, label)
+    all_annotations: list[tuple[uuid.UUID, uuid.UUID, str]] = []
+    if all_comment_ids:
+        all_annotations = (
+            db.query(
+                Annotation.comment_id,
+                Annotation.annotator_id,
+                Annotation.label,
+            )
+            .filter(Annotation.comment_id.in_(all_comment_ids))
+            .all()
+        )
+
+    # Agrupar: comment_id → [(annotator_id, label)]
+    anns_by_comment: dict[uuid.UUID, list[tuple[uuid.UUID, str]]] = defaultdict(list)
+    for comment_id, annotator_id, label in all_annotations:
+        anns_by_comment[comment_id].append((annotator_id, label))
+
+    # 4) Batch: conflitos (comment_id, status, resolved_label)
+    all_conflicts: list[tuple[uuid.UUID, str, str | None]] = []
+    if all_comment_ids:
+        all_conflicts = (
+            db.query(
+                AnnotationConflict.comment_id,
+                AnnotationConflict.status,
+                AnnotationConflict.resolved_label,
+            )
+            .filter(AnnotationConflict.comment_id.in_(all_comment_ids))
+            .all()
+        )
+
+    # conflict_comment_id → (status, resolved_label)
+    conflict_map: dict[uuid.UUID, tuple[str, str | None]] = {}
+    for comment_id, status, resolved_label in all_conflicts:
+        conflict_map[comment_id] = (status, resolved_label)
+
+    # 5) Montar resultados por dataset — tudo em Python, sem mais queries
+    results = []
+    for ds in datasets:
+        ds_authors = authors_by_ds.get(ds.id, [])
+
+        if not ds_authors:
+            results.append(
+                {
+                    "dataset_id": ds.id,
+                    "dataset_name": ds.name,
+                    "total": 0,
+                    "annotated": 0,
+                    "pending": 0,
+                    "conflicts": 0,
+                    "conflicts_resolved": 0,
+                    "annotators_count": 0,
+                    "bots_users": 0,
+                    "bots_comments": 0,
+                }
+            )
+            continue
+
+        # Comentários deste dataset
+        ds_comment_ids: list[uuid.UUID] = []
+        for author_id in ds_authors:
+            ds_comment_ids.extend(
+                comments_by_col_author.get((ds_col_map[ds.id], author_id), [])
+            )
+
+        total = len(ds_comment_ids)
+
+        # Anotados: comentários com pelo menos uma anotação
+        annotated_set: set[uuid.UUID] = set()
+        annotator_ids: set[uuid.UUID] = set()
+        for cid in ds_comment_ids:
+            anns = anns_by_comment.get(cid)
+            if anns:
+                annotated_set.add(cid)
+                for annotator_id, _ in anns:
+                    annotator_ids.add(annotator_id)
+
+        annotated = len(annotated_set)
+
+        # Conflitos
+        conflicts = 0
+        conflicts_resolved = 0
+        for cid in ds_comment_ids:
+            if cid in conflict_map:
+                conflicts += 1
+                if conflict_map[cid][0] == "resolved":
+                    conflicts_resolved += 1
+
+        # Bots: consenso "bot" (sem conflito) OU conflito resolvido como "bot"
+        bots_comments = 0
+        bot_author_ids: set[str] = set()
+        for cid in ds_comment_ids:
+            anns = anns_by_comment.get(cid, [])
+            if not anns:
+                continue
+
+            if cid in conflict_map:
+                # Tem conflito — só conta se resolvido como bot
+                status, resolved_label = conflict_map[cid]
+                if status == "resolved" and resolved_label == "bot":
+                    bots_comments += 1
+                    _, author_id = comment_info[cid]
+                    bot_author_ids.add(author_id)
+            else:
+                # Sem conflito — consenso
+                if all(label == "bot" for _, label in anns):
+                    bots_comments += 1
+                    _, author_id = comment_info[cid]
+                    bot_author_ids.add(author_id)
+
+        results.append(
+            {
+                "dataset_id": ds.id,
+                "dataset_name": ds.name,
+                "total": total,
+                "annotated": annotated,
+                "pending": total - annotated,
+                "conflicts": conflicts,
+                "conflicts_resolved": conflicts_resolved,
+                "annotators_count": len(annotator_ids),
+                "bots_users": len(bot_author_ids),
+                "bots_comments": bots_comments,
+            }
+        )
+
+    return results

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -1,0 +1,426 @@
+"""Testes da US-07 — catálogo centralizado de dados."""
+
+import uuid
+from datetime import datetime, timedelta
+
+from models.annotation import Annotation, AnnotationConflict
+from models.collection import Collection, Comment
+from models.dataset import Dataset, DatasetEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_collection(db, user_id, *, video_id="vid123", status="completed"):
+    col = Collection(
+        video_id=video_id,
+        status=status,
+        collected_by=user_id,
+        total_comments=5,
+    )
+    db.add(col)
+    db.flush()
+    return col
+
+
+def _make_comments(db, collection_id, author_channel_id, count=5):
+    comments = []
+    for i in range(count):
+        c = Comment(
+            collection_id=collection_id,
+            comment_id=f"{author_channel_id}_c{i}",
+            author_channel_id=author_channel_id,
+            author_display_name=f"User {author_channel_id}",
+            text_original=f"Comentario {i} do {author_channel_id}",
+            like_count=i,
+            reply_count=0,
+            published_at=datetime(2024, 1, 1) + timedelta(minutes=i),
+            updated_at=datetime(2024, 1, 1) + timedelta(minutes=i),
+        )
+        db.add(c)
+        comments.append(c)
+    db.flush()
+    return comments
+
+
+def _make_dataset(db, collection_id, user_id, author_channel_ids):
+    ds = Dataset(
+        name=f"test_dataset_{uuid.uuid4().hex[:6]}",
+        collection_id=collection_id,
+        criteria_applied=["percentil"],
+        thresholds={},
+        total_users_original=10,
+        total_users_selected=len(author_channel_ids),
+        created_by=user_id,
+    )
+    db.add(ds)
+    db.flush()
+    for channel_id in author_channel_ids:
+        entry = DatasetEntry(
+            dataset_id=ds.id,
+            author_channel_id=channel_id,
+            author_display_name=f"User {channel_id}",
+            comment_count=5,
+            matched_criteria=["percentil"],
+        )
+        db.add(entry)
+    db.flush()
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# GET /data/summary
+# ---------------------------------------------------------------------------
+
+
+class TestSummary:
+    def test_summary_retorna_contadores_corretos(self, client, db, auth_as_user):
+        """Inserir 2 coletas com 5 comentários cada → counts corretos."""
+        col1 = _make_collection(db, auth_as_user.id, video_id="vid1")
+        col2 = _make_collection(db, auth_as_user.id, video_id="vid2")
+        _make_comments(db, col1.id, "author_a", count=5)
+        _make_comments(db, col2.id, "author_b", count=5)
+        db.commit()
+
+        resp = client.get("/data/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["collections_count"] == 2
+        assert data["comments_count"] == 10
+        assert data["datasets_count"] == 0
+        assert data["annotations_count"] == 0
+        assert data["estimated_size_mb"] >= 0
+
+    def test_summary_sem_token_retorna_401(self, client):
+        resp = client.get("/data/summary")
+        assert resp.status_code == 401
+
+    def test_summary_vazio(self, client, auth_as_user):
+        """Banco vazio retorna zeros."""
+        resp = client.get("/data/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["collections_count"] == 0
+        assert data["comments_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /data/collections
+# ---------------------------------------------------------------------------
+
+
+class TestCollections:
+    def test_listagem_compartilhada(self, client, db, auth_as_user, admin_user):
+        """User A cria coleta, user B (auth_as_user) consegue ver."""
+        _make_collection(db, admin_user.id, video_id="vid_admin")
+        db.commit()
+
+        resp = client.get("/data/collections")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["video_id"] == "vid_admin"
+
+    def test_collections_sem_token_retorna_401(self, client):
+        resp = client.get("/data/collections")
+        assert resp.status_code == 401
+
+    def test_collections_retorna_campos_esperados(self, client, db, auth_as_user):
+        col = _make_collection(db, auth_as_user.id, video_id="vid_check")
+        _make_comments(db, col.id, "author_a", count=3)
+        _make_comments(db, col.id, "author_b", count=2)
+        db.commit()
+
+        resp = client.get("/data/collections")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        item = data[0]
+        assert item["collection_id"] == str(col.id)
+        assert item["video_id"] == "vid_check"
+        assert item["status"] == "completed"
+        assert item["total_users"] == 2
+        assert "created_at" in item
+        assert "collected_by" in item
+        assert "duration_seconds" in item
+        assert "completed_at" in item
+
+    def test_collections_vazio(self, client, auth_as_user):
+        resp = client.get("/data/collections")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_delete_coleta_em_andamento_retorna_409(self, client, db, auth_as_user):
+        """Coleta com status running não pode ser deletada."""
+        col = _make_collection(
+            db, auth_as_user.id, video_id="vid_running", status="running"
+        )
+        db.commit()
+
+        resp = client.delete(f"/collect/{col.id}")
+        assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# GET /data/datasets
+# ---------------------------------------------------------------------------
+
+
+class TestDatasets:
+    def test_datasets_retorna_lista_vazia(self, client, auth_as_user):
+        """Sem datasets cadastrados retorna []."""
+        resp = client.get("/data/datasets")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_datasets_sem_token_retorna_401(self, client):
+        resp = client.get("/data/datasets")
+        assert resp.status_code == 401
+
+    def test_datasets_retorna_campos_completos(self, client, db, auth_as_user):
+        """Verifica todos os campos do dataset: video_id, comments, created_by."""
+        col = _make_collection(db, auth_as_user.id, video_id="vid_ds")
+        _make_comments(db, col.id, "ch1", count=4)
+        _make_comments(db, col.id, "ch2", count=3)
+        ds = _make_dataset(db, col.id, auth_as_user.id, ["ch1", "ch2"])
+        db.commit()
+
+        resp = client.get("/data/datasets")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        item = data[0]
+        assert item["dataset_id"] == str(ds.id)
+        assert item["name"] == ds.name
+        assert item["video_id"] == "vid_ds"
+        assert item["criteria"] == ["percentil"]
+        assert item["total_selected"] == 2
+        assert item["total_users_original"] == 10
+        assert item["total_comments"] == 7  # 4 + 3
+        assert item["created_by"] == auth_as_user.username
+        assert "created_at" in item
+
+
+# ---------------------------------------------------------------------------
+# GET /data/annotations
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotations:
+    def test_annotations_retorna_lista_vazia(self, client, auth_as_user):
+        """Sem datasets/anotações retorna []."""
+        resp = client.get("/data/annotations")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_annotations_sem_token_retorna_401(self, client):
+        resp = client.get("/data/annotations")
+        assert resp.status_code == 401
+
+    def test_annotations_progresso_com_conflito_pendente(
+        self, client, db, auth_as_user, admin_user
+    ):
+        """Dataset com conflito pendente: bots_comments=0 (sem rótulo final)."""
+        col = _make_collection(db, auth_as_user.id)
+        comments = _make_comments(db, col.id, "ch_ann", count=3)
+        ds = _make_dataset(db, col.id, auth_as_user.id, ["ch_ann"])
+
+        # Anotar 2 dos 3 comentários
+        ann1 = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=auth_as_user.id,
+            label="bot",
+            justificativa="teste",
+        )
+        ann2 = Annotation(
+            comment_id=comments[1].id,
+            annotator_id=auth_as_user.id,
+            label="humano",
+        )
+        db.add_all([ann1, ann2])
+        db.flush()
+
+        # Conflito pendente no primeiro comentário
+        ann1_admin = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=admin_user.id,
+            label="humano",
+        )
+        db.add(ann1_admin)
+        db.flush()
+
+        conflict = AnnotationConflict(
+            comment_id=comments[0].id,
+            annotation_a_id=ann1.id,
+            annotation_b_id=ann1_admin.id,
+            status="pending",
+        )
+        db.add(conflict)
+        db.commit()
+
+        resp = client.get("/data/annotations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        progress = data[0]
+        assert progress["dataset_id"] == str(ds.id)
+        assert progress["total"] == 3
+        assert progress["annotated"] == 2
+        assert progress["pending"] == 1
+        assert progress["conflicts"] == 1
+        assert progress["conflicts_resolved"] == 0
+        assert progress["annotators_count"] == 2
+        # Conflito pendente → sem rótulo final de bot
+        assert progress["bots_comments"] == 0
+        assert progress["bots_users"] == 0
+
+    def test_bots_por_consenso(self, client, db, auth_as_user, admin_user):
+        """Dois anotadores concordam como bot → bots_comments=1, bots_users=1."""
+        col = _make_collection(db, auth_as_user.id, video_id="vid_bot_cons")
+        comments = _make_comments(db, col.id, "ch_bot", count=2)
+        _make_dataset(db, col.id, auth_as_user.id, ["ch_bot"])
+
+        # Ambos anotam comment[0] como bot (consenso)
+        db.add(
+            Annotation(
+                comment_id=comments[0].id,
+                annotator_id=auth_as_user.id,
+                label="bot",
+                justificativa="padrão",
+            )
+        )
+        db.add(
+            Annotation(
+                comment_id=comments[0].id,
+                annotator_id=admin_user.id,
+                label="bot",
+                justificativa="concordo",
+            )
+        )
+        # Comment[1] anotado como humano
+        db.add(
+            Annotation(
+                comment_id=comments[1].id,
+                annotator_id=auth_as_user.id,
+                label="humano",
+            )
+        )
+        db.commit()
+
+        resp = client.get("/data/annotations")
+        data = resp.json()
+        assert len(data) == 1
+        progress = data[0]
+        assert progress["bots_comments"] == 1
+        assert progress["bots_users"] == 1
+        assert progress["annotated"] == 2
+        assert progress["conflicts"] == 0
+
+    def test_bots_por_conflito_resolvido(self, client, db, auth_as_user, admin_user):
+        """Conflito resolvido como bot → conta em bots_comments e bots_users."""
+        col = _make_collection(db, auth_as_user.id, video_id="vid_bot_res")
+        comments = _make_comments(db, col.id, "ch_resolved", count=1)
+        _make_dataset(db, col.id, auth_as_user.id, ["ch_resolved"])
+
+        # Anotações divergentes
+        ann_a = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=auth_as_user.id,
+            label="bot",
+            justificativa="spam",
+        )
+        ann_b = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=admin_user.id,
+            label="humano",
+        )
+        db.add_all([ann_a, ann_b])
+        db.flush()
+
+        # Conflito resolvido como bot
+        conflict = AnnotationConflict(
+            comment_id=comments[0].id,
+            annotation_a_id=ann_a.id,
+            annotation_b_id=ann_b.id,
+            status="resolved",
+            resolved_by=admin_user.id,
+            resolved_label="bot",
+            resolved_at=datetime(2026, 3, 20),
+        )
+        db.add(conflict)
+        db.commit()
+
+        resp = client.get("/data/annotations")
+        data = resp.json()
+        assert len(data) == 1
+        progress = data[0]
+        assert progress["bots_comments"] == 1
+        assert progress["bots_users"] == 1
+        assert progress["conflicts"] == 1
+        assert progress["conflicts_resolved"] == 1
+
+    def test_conflito_resolvido_como_humano_nao_conta_bot(
+        self, client, db, auth_as_user, admin_user
+    ):
+        """Conflito resolvido como humano → bots_comments=0."""
+        col = _make_collection(db, auth_as_user.id, video_id="vid_hum_res")
+        comments = _make_comments(db, col.id, "ch_hum", count=1)
+        _make_dataset(db, col.id, auth_as_user.id, ["ch_hum"])
+
+        ann_a = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=auth_as_user.id,
+            label="bot",
+            justificativa="parece bot",
+        )
+        ann_b = Annotation(
+            comment_id=comments[0].id,
+            annotator_id=admin_user.id,
+            label="humano",
+        )
+        db.add_all([ann_a, ann_b])
+        db.flush()
+
+        conflict = AnnotationConflict(
+            comment_id=comments[0].id,
+            annotation_a_id=ann_a.id,
+            annotation_b_id=ann_b.id,
+            status="resolved",
+            resolved_by=admin_user.id,
+            resolved_label="humano",
+            resolved_at=datetime(2026, 3, 20),
+        )
+        db.add(conflict)
+        db.commit()
+
+        resp = client.get("/data/annotations")
+        data = resp.json()
+        progress = data[0]
+        assert progress["bots_comments"] == 0
+        assert progress["bots_users"] == 0
+
+    def test_dataset_sem_entries_retorna_zeros(self, client, db, auth_as_user):
+        """Dataset vazio (sem entries) retorna todos os contadores zerados."""
+        col = _make_collection(db, auth_as_user.id, video_id="vid_empty")
+        # Dataset sem entries
+        ds = Dataset(
+            name=f"empty_{uuid.uuid4().hex[:6]}",
+            collection_id=col.id,
+            criteria_applied=["percentil"],
+            thresholds={},
+            total_users_original=0,
+            total_users_selected=0,
+            created_by=auth_as_user.id,
+        )
+        db.add(ds)
+        db.commit()
+
+        resp = client.get("/data/annotations")
+        data = resp.json()
+        assert len(data) == 1
+        progress = data[0]
+        assert progress["total"] == 0
+        assert progress["annotated"] == 0
+        assert progress["bots_comments"] == 0
+        assert progress["annotators_count"] == 0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { CleanPage } from "./pages/Clean/CleanPage";
 import { CollectPage } from "./pages/Collect/CollectPage";
 import { HomePage } from "./pages/Home/HomePage";
 import { ReviewPage } from "./pages/Review/ReviewPage";
+import { DataPage } from "./pages/Data/DataPage";
 import { UsersPage } from "./pages/Users/UsersPage";
 
 export function App() {
@@ -26,6 +27,7 @@ export function App() {
             <Route path="/collect" element={<CollectPage />} />
             <Route path="/clean" element={<CleanPage />} />
             <Route path="/annotate" element={<AnnotatePage />} />
+            <Route path="/data" element={<DataPage />} />
           </Route>
 
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -1,0 +1,60 @@
+import { request } from "./http";
+
+export interface DataSummary {
+  collections_count: number;
+  comments_count: number;
+  datasets_count: number;
+  annotations_count: number;
+  estimated_size_mb: number;
+}
+
+export interface DataCollection {
+  collection_id: string;
+  video_id: string;
+  video_title: string | null;
+  total_comments: number | null;
+  status: string;
+  enrich_status: string | null;
+  channel_dates_failed: boolean | null;
+  total_users: number;
+  collected_by: string;
+  created_at: string;
+  completed_at: string | null;
+  duration_seconds: number | null;
+}
+
+export interface DataDataset {
+  dataset_id: string;
+  name: string;
+  collection_id: string;
+  video_id: string;
+  criteria: string[];
+  total_users_original: number;
+  total_selected: number;
+  total_comments: number;
+  created_by: string;
+  created_at: string;
+}
+
+export interface DataAnnotationProgress {
+  dataset_id: string;
+  dataset_name: string;
+  total: number;
+  annotated: number;
+  pending: number;
+  conflicts: number;
+  conflicts_resolved: number;
+  annotators_count: number;
+  bots_users: number;
+  bots_comments: number;
+}
+
+export const dataApi = {
+  summary: (token: string) => request<DataSummary>("/data/summary", {}, token),
+
+  collections: (token: string) => request<DataCollection[]>("/data/collections", {}, token),
+
+  datasets: (token: string) => request<DataDataset[]>("/data/datasets", {}, token),
+
+  annotations: (token: string) => request<DataAnnotationProgress[]>("/data/annotations", {}, token),
+};

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -7,6 +7,8 @@ const LABEL: Record<string, string> = {
   enriching_replies: "Coletando respostas",
   enriching_channels: "Coletando dados dos autores",
   enriching: "Enriquecendo dados",
+  done: "Concluído",
+  importing: "Importando",
 };
 
 const COLOR: Record<string, string> = {
@@ -18,6 +20,8 @@ const COLOR: Record<string, string> = {
   enriching_replies: "bg-purple-50 text-purple-700",
   enriching_channels: "bg-purple-50 text-purple-700",
   enriching: "bg-purple-50 text-purple-700",
+  done: "bg-green-50 text-green-600",
+  importing: "bg-blue-50 text-blue-700",
 };
 
 interface StatusBadgeProps {

--- a/frontend/src/hooks/useData.ts
+++ b/frontend/src/hooks/useData.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  dataApi,
+  DataAnnotationProgress,
+  DataCollection,
+  DataDataset,
+  DataSummary,
+} from "../api/data";
+import { annotateApi } from "../api/annotate";
+import { cleanApi } from "../api/clean";
+import { collectApi } from "../api/collect";
+import { reviewApi } from "../api/review";
+import { useAuthContext } from "../contexts/AuthContext";
+
+interface DataState {
+  loading: boolean;
+  error: string | null;
+  summary: DataSummary | null;
+  collections: DataCollection[];
+  datasets: DataDataset[];
+  annotations: DataAnnotationProgress[];
+}
+
+export function useData() {
+  const { token } = useAuthContext();
+  const [state, setState] = useState<DataState>({
+    loading: false,
+    error: null,
+    summary: null,
+    collections: [],
+    datasets: [],
+    annotations: [],
+  });
+
+  const loadAll = useCallback(async () => {
+    if (!token) return;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const [summary, collections, datasets, annotations] = await Promise.all([
+        dataApi.summary(token),
+        dataApi.collections(token),
+        dataApi.datasets(token),
+        dataApi.annotations(token),
+      ]);
+      setState({
+        loading: false,
+        error: null,
+        summary,
+        collections,
+        datasets,
+        annotations,
+      });
+    } catch (err) {
+      setState((s) => ({
+        ...s,
+        loading: false,
+        error: err instanceof Error ? err.message : "Erro ao carregar dados.",
+      }));
+    }
+  }, [token]);
+
+  const deleteCollection = useCallback(
+    async (collectionId: string) => {
+      if (!token) return;
+      await collectApi.delete(collectionId, token);
+      await loadAll();
+    },
+    [token, loadAll]
+  );
+
+  const exportCollection = useCallback(
+    async (collectionId: string, format: "json" | "csv", videoId: string) => {
+      if (!token) return;
+      await collectApi.downloadExport(collectionId, format, token, videoId);
+    },
+    [token]
+  );
+
+  const downloadDataset = useCallback(
+    async (datasetId: string, format: "json" | "csv", datasetName: string) => {
+      if (!token) return;
+      await cleanApi.download(datasetId, format, token, datasetName);
+    },
+    [token]
+  );
+
+  const deleteDataset = useCallback(
+    async (datasetId: string) => {
+      if (!token) return;
+      await cleanApi.delete(datasetId, token);
+      await loadAll();
+    },
+    [token, loadAll]
+  );
+
+  const exportAnnotations = useCallback(
+    async (datasetId: string, format: "json" | "csv") => {
+      if (!token) return;
+      await annotateApi.downloadExport(format, token, datasetId);
+    },
+    [token]
+  );
+
+  const exportReview = useCallback(
+    async (datasetId: string, format: "json" | "csv") => {
+      if (!token) return;
+      await reviewApi.downloadExport(format, token, datasetId);
+    },
+    [token]
+  );
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  return {
+    ...state,
+    loadAll,
+    deleteCollection,
+    deleteDataset,
+    exportCollection,
+    exportAnnotations,
+    downloadDataset,
+    exportReview,
+  };
+}

--- a/frontend/src/pages/Data/DataPage.tsx
+++ b/frontend/src/pages/Data/DataPage.tsx
@@ -1,0 +1,930 @@
+import { useState } from "react";
+import { PageHeader } from "../../components/PageHeader";
+import { StatusBadge } from "../../components/StatusBadge";
+import { StepsCard } from "../../components/StepsCard";
+import { useData } from "../../hooks/useData";
+import { ChangePasswordModal } from "../Home/ChangePasswordModal";
+import { usersApi } from "../../api/users";
+import { useAuthContext } from "../../contexts/AuthContext";
+import type { DataCollection } from "../../api/data";
+import type { DataDataset, DataAnnotationProgress } from "../../api/data";
+
+// ─── Icons ──────────────────────────────────────────────────────────────────
+
+function IconChevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+    </svg>
+  );
+}
+
+function IconRefresh() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="w-4 h-4"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182"
+      />
+    </svg>
+  );
+}
+
+function IconX() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="w-4 h-4"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ─── Detail Field ───────────────────────────────────────────────────────────
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-[10px] font-bold uppercase tracking-wider text-gray-400 mb-0.5">{label}</p>
+      <p className="text-xs text-gray-700">{value}</p>
+    </div>
+  );
+}
+
+// ─── Summary Card ───────────────────────────────────────────────────────────
+
+function SummaryCard({
+  summary,
+}: {
+  summary: {
+    collections_count: number;
+    comments_count: number;
+    datasets_count: number;
+    annotations_count: number;
+    estimated_size_mb: number;
+  } | null;
+}) {
+  if (!summary) return null;
+
+  const NEON_LIMIT_MB = 512;
+  const usagePercent = Math.min(100, (summary.estimated_size_mb / NEON_LIMIT_MB) * 100);
+
+  const counters = [
+    { label: "Coletas", value: summary.collections_count },
+    { label: "Comentários", value: summary.comments_count },
+    { label: "Datasets", value: summary.datasets_count },
+    { label: "Anotações", value: summary.annotations_count },
+  ];
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5 mb-6">
+      <h3 className="text-xs font-bold uppercase tracking-wider text-gray-400 mb-4">
+        Resumo do banco
+      </h3>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-5">
+        {counters.map((c) => (
+          <div key={c.label} className="text-center">
+            <p className="text-2xl font-bold text-gray-800">{c.value.toLocaleString("pt-BR")}</p>
+            <p className="text-xs text-gray-500">{c.label}</p>
+          </div>
+        ))}
+      </div>
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <p className="text-xs font-medium text-gray-600">
+            Uso estimado do banco (Neon free tier)
+          </p>
+          <p className="text-xs font-semibold text-gray-700">
+            {summary.estimated_size_mb} MB / {NEON_LIMIT_MB} MB
+          </p>
+        </div>
+        <div className="w-full h-2.5 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${
+              usagePercent > 80
+                ? "bg-red-400"
+                : usagePercent > 50
+                  ? "bg-yellow-400"
+                  : "bg-davint-400"
+            }`}
+            style={{ width: `${usagePercent}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Collapsible Section ────────────────────────────────────────────────────
+
+function Section({
+  title,
+  count,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  count: number;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 mb-4">
+      <button
+        className="w-full flex items-center justify-between px-5 py-4 text-left"
+        onClick={() => setOpen(!open)}
+      >
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-gray-800">{title}</h3>
+          <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">
+            {count}
+          </span>
+        </div>
+        <IconChevron open={open} />
+      </button>
+      {open && <div className="px-5 pb-5">{children}</div>}
+    </div>
+  );
+}
+
+// ─── Detail Panels ──────────────────────────────────────────────────────────
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "—";
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s > 0 ? `${m}min ${s}s` : `${m}min`;
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function CollectionDetail({
+  col,
+  onExport,
+  onDelete,
+  onClose,
+}: {
+  col: DataCollection;
+  onExport: (format: "json" | "csv") => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="mt-3 bg-gray-50 rounded-lg border border-gray-200 p-4 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-xs font-bold text-gray-700">Detalhes da coleta</h4>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <IconX />
+        </button>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <Field label="ID do vídeo" value={col.video_id} />
+        <Field label="Título" value={col.video_title || "—"} />
+        <Field label="Status" value={<StatusBadge status={col.status} size="sm" />} />
+        <Field
+          label="Enriquecimento"
+          value={col.enrich_status ? <StatusBadge status={col.enrich_status} size="sm" /> : "—"}
+        />
+        <Field label="Comentários" value={col.total_comments?.toLocaleString("pt-BR") ?? "—"} />
+        <Field label="Usuários" value={col.total_users.toLocaleString("pt-BR")} />
+        <Field label="Coletado por" value={col.collected_by} />
+        <Field label="Início da coleta" value={formatDateTime(col.created_at)} />
+        <Field
+          label="Conclusão"
+          value={col.completed_at ? formatDateTime(col.completed_at) : "—"}
+        />
+        <Field label="Duração" value={formatDuration(col.duration_seconds)} />
+        <Field
+          label="Canais sem data"
+          value={
+            col.channel_dates_failed === true
+              ? "Sim"
+              : col.channel_dates_failed === false
+                ? "Não"
+                : "—"
+          }
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("json")}>
+          Exportar JSON
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("csv")}>
+          Exportar CSV
+        </button>
+        <button
+          className="btn btn-danger btn-sm ml-auto"
+          onClick={onDelete}
+          disabled={col.status === "running"}
+        >
+          Deletar coleta
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DatasetDetail({
+  ds,
+  onDownload,
+  onDelete,
+  onClose,
+}: {
+  ds: DataDataset;
+  onDownload: (format: "json" | "csv") => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="mt-3 bg-gray-50 rounded-lg border border-gray-200 p-4 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-xs font-bold text-gray-700">Detalhes do dataset</h4>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <IconX />
+        </button>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <Field label="Nome" value={ds.name} />
+        <Field label="Vídeo" value={ds.video_id} />
+        <Field
+          label="Critérios"
+          value={
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {ds.criteria.map((c) => (
+                <span
+                  key={c}
+                  className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-davint-50 text-davint-400"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          }
+        />
+        <Field
+          label="Usuários"
+          value={`${ds.total_selected} selecionados de ${ds.total_users_original} total`}
+        />
+        <Field label="Comentários" value={ds.total_comments.toLocaleString("pt-BR")} />
+        <Field label="Criado por" value={ds.created_by} />
+        <Field label="Criado em" value={formatDateTime(ds.created_at)} />
+      </div>
+      <div className="flex items-center gap-2">
+        <button className="btn btn-ghost btn-sm" onClick={() => onDownload("json")}>
+          Exportar JSON
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={() => onDownload("csv")}>
+          Exportar CSV
+        </button>
+        <button className="btn btn-danger btn-sm ml-auto" onClick={onDelete}>
+          Deletar dataset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AnnotationDetail({
+  ann,
+  onExport,
+  onDelete,
+  onClose,
+}: {
+  ann: DataAnnotationProgress;
+  onExport: (format: "json" | "csv") => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const isComplete = ann.total > 0 && ann.pending === 0 && ann.conflicts === ann.conflicts_resolved;
+  const progressPct = ann.total > 0 ? Math.round((ann.annotated / ann.total) * 100) : 0;
+
+  return (
+    <div className="mt-3 bg-gray-50 rounded-lg border border-gray-200 p-4 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-xs font-bold text-gray-700">Progresso de anotação</h4>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <IconX />
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mb-4">
+        <div className="flex justify-between mb-1">
+          <p className="text-xs text-gray-500">
+            {ann.annotated} de {ann.total} comentários anotados
+          </p>
+          <p className="text-xs font-semibold text-gray-600">{progressPct}%</p>
+        </div>
+        <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${isComplete ? "bg-green-400" : "bg-davint-400"}`}
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <Field label="Dataset" value={ann.dataset_name} />
+        <Field label="Anotadores" value={ann.annotators_count} />
+        <Field label="Pendentes" value={ann.pending} />
+        <Field
+          label="Conflitos"
+          value={`${ann.conflicts_resolved} resolvidos / ${ann.conflicts} total`}
+        />
+        <Field label="Bots (comentários)" value={ann.bots_comments} />
+        <Field label="Bots (usuários)" value={ann.bots_users} />
+        <Field
+          label="Status"
+          value={
+            <span
+              className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${
+                isComplete ? "bg-green-50 text-green-600" : "bg-yellow-50 text-yellow-600"
+              }`}
+            >
+              {isComplete ? "Concluído" : "Em andamento"}
+            </span>
+          }
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("json")}>
+          Exportar JSON
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("csv")}>
+          Exportar CSV
+        </button>
+        <button className="btn btn-danger btn-sm ml-auto" onClick={onDelete}>
+          Deletar dataset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TrainingDetail({
+  ds,
+  onExport,
+  onDelete,
+  onClose,
+}: {
+  ds: DataAnnotationProgress;
+  onExport: (format: "json" | "csv") => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="mt-3 bg-gray-50 rounded-lg border border-gray-200 p-4 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-xs font-bold text-gray-700">Dados para treinamento</h4>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <IconX />
+        </button>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <Field label="Dataset" value={ds.dataset_name} />
+        <Field label="Comentários" value={ds.total} />
+        <Field label="Anotadores" value={ds.annotators_count} />
+        <Field label="Conflitos resolvidos" value={ds.conflicts_resolved} />
+        <Field label="Bots detectados (comentários)" value={ds.bots_comments} />
+        <Field label="Bots detectados (usuários)" value={ds.bots_users} />
+        <Field label="Humanos (comentários)" value={ds.total - ds.bots_comments} />
+      </div>
+
+      <div className="flex items-start gap-2 p-3 bg-davint-50 rounded-lg mb-3">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-4 h-4 text-davint-400 flex-shrink-0 mt-0.5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+          />
+        </svg>
+        <p className="text-xs text-davint-700">
+          O export inclui o rótulo final de cada comentário (bot ou humano), as anotações
+          individuais e as resoluções de conflito.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("json")}>
+          Exportar JSON
+        </button>
+        <button className="btn btn-ghost btn-sm" onClick={() => onExport("csv")}>
+          Exportar CSV
+        </button>
+        <button className="btn btn-danger btn-sm ml-auto" onClick={onDelete}>
+          Deletar dataset
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Table header helper ────────────────────────────────────────────────────
+
+const TH_CLS = "text-[11px] font-bold uppercase tracking-wider text-gray-400 pb-2";
+
+// ─── DataPage ───────────────────────────────────────────────────────────────
+
+export function DataPage() {
+  const { token } = useAuthContext();
+  const {
+    loading,
+    error,
+    summary,
+    collections,
+    datasets,
+    annotations,
+    loadAll,
+    deleteCollection,
+    deleteDataset,
+    exportCollection,
+    exportAnnotations,
+    downloadDataset,
+    exportReview,
+  } = useData();
+
+  const [showChangePassword, setShowChangePassword] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Selected items for detail panels
+  const [selectedCol, setSelectedCol] = useState<string | null>(null);
+  const [selectedDs, setSelectedDs] = useState<string | null>(null);
+  const [selectedAnn, setSelectedAnn] = useState<string | null>(null);
+  const [selectedTraining, setSelectedTraining] = useState<string | null>(null);
+
+  // Fecha todos os painéis de outras seções ao abrir um novo
+  const closeAllPanels = () => {
+    setSelectedCol(null);
+    setSelectedDs(null);
+    setSelectedAnn(null);
+    setSelectedTraining(null);
+  };
+
+  const togglePanel = (current: string | null, id: string, setter: (v: string | null) => void) => {
+    if (current === id) {
+      setter(null);
+    } else {
+      closeAllPanels();
+      setter(id);
+    }
+  };
+
+  const handleDelete = async (col: DataCollection) => {
+    if (col.status === "running") {
+      setActionError("Não é possível deletar uma coleta em andamento.");
+      return;
+    }
+    if (!window.confirm("Tem certeza que deseja deletar esta coleta e todos os dados associados?"))
+      return;
+    setActionError(null);
+    try {
+      await deleteCollection(col.collection_id);
+      setSelectedCol(null);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Erro ao deletar coleta.");
+    }
+  };
+
+  const handleDeleteDataset = async (datasetId: string) => {
+    if (!window.confirm("Tem certeza que deseja deletar este dataset e todos os dados associados?"))
+      return;
+    setActionError(null);
+    try {
+      await deleteDataset(datasetId);
+      setSelectedDs(null);
+      setSelectedAnn(null);
+      setSelectedTraining(null);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Erro ao deletar dataset.");
+    }
+  };
+
+  const withErrorHandling = async (fn: () => Promise<void>, fallback: string) => {
+    setActionError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : fallback);
+    }
+  };
+
+  const completedDatasets = annotations.filter(
+    (a) => a.total > 0 && a.pending === 0 && a.conflicts === a.conflicts_resolved
+  );
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <PageHeader
+        breadcrumbs={[{ label: "Início", to: "/" }, { label: "Catálogo de Dados" }]}
+        onChangePassword={() => setShowChangePassword(true)}
+      />
+
+      <main className="flex-1 px-8 py-9 max-w-6xl w-full mx-auto">
+        <StepsCard
+          title="Catálogo de Dados"
+          steps={[
+            {
+              label: "Resumo do banco",
+              description:
+                "Veja quantas coletas, comentários, datasets e anotações existem, e o uso estimado do banco.",
+            },
+            {
+              label: "Gerencie coletas e datasets",
+              description: "Clique em qualquer item para ver detalhes, exportar ou deletar.",
+            },
+            {
+              label: "Exporte dados para treinamento",
+              description:
+                "Datasets com anotação concluída e conflitos resolvidos ficam prontos para exportar.",
+            },
+          ]}
+        />
+
+        {(error || actionError) && (
+          <div className="alert alert-error mb-4">{error || actionError}</div>
+        )}
+
+        {loading && (
+          <div className="flex items-center gap-2 p-3 bg-davint-50 rounded-lg mb-4">
+            <svg
+              className="w-4 h-4 text-davint-400 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            <p className="text-xs text-davint-700">Carregando dados do catálogo...</p>
+          </div>
+        )}
+
+        {!loading && (
+          <>
+            <div className="flex justify-end mb-4">
+              <button className="btn btn-ghost btn-sm flex items-center gap-1.5" onClick={loadAll}>
+                <IconRefresh />
+                Atualizar
+              </button>
+            </div>
+
+            <SummaryCard summary={summary} />
+
+            {/* ── Coletas ── */}
+            <Section title="Coletas" count={collections.length}>
+              {collections.length === 0 ? (
+                <p className="text-xs text-gray-400 py-2">Nenhuma coleta encontrada.</p>
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left">
+                      <thead>
+                        <tr>
+                          <th className={TH_CLS}>Vídeo</th>
+                          <th className={TH_CLS}>Comentários</th>
+                          <th className={TH_CLS}>Status</th>
+                          <th className={TH_CLS}>Data</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {collections.map((col) => (
+                          <tr
+                            key={col.collection_id}
+                            className={`cursor-pointer transition-colors ${selectedCol === col.collection_id ? "bg-davint-50" : "hover:bg-gray-50"}`}
+                            onClick={() =>
+                              togglePanel(selectedCol, col.collection_id, setSelectedCol)
+                            }
+                          >
+                            <td className="py-2.5 pr-3">
+                              <p className="text-xs font-medium text-gray-800 truncate max-w-[280px]">
+                                {col.video_title || col.video_id}
+                              </p>
+                              <p className="text-[10px] text-gray-400">{col.video_id}</p>
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-600">
+                              {col.total_comments?.toLocaleString("pt-BR") ?? "—"}
+                            </td>
+                            <td className="py-2.5 pr-3">
+                              <StatusBadge status={col.status} size="sm" />
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-500">
+                              {new Date(col.created_at).toLocaleDateString("pt-BR")}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  {selectedCol &&
+                    (() => {
+                      const col = collections.find((c) => c.collection_id === selectedCol);
+                      if (!col) return null;
+                      return (
+                        <CollectionDetail
+                          col={col}
+                          onExport={(fmt) =>
+                            withErrorHandling(
+                              () => exportCollection(col.collection_id, fmt, col.video_id),
+                              "Erro ao exportar."
+                            )
+                          }
+                          onDelete={() => handleDelete(col)}
+                          onClose={() => setSelectedCol(null)}
+                        />
+                      );
+                    })()}
+                </>
+              )}
+            </Section>
+
+            {/* ── Datasets ── */}
+            <Section title="Datasets" count={datasets.length} defaultOpen={datasets.length > 0}>
+              {datasets.length === 0 ? (
+                <p className="text-xs text-gray-400 py-2">
+                  Nenhum dataset encontrado. Crie um dataset na etapa de Limpeza.
+                </p>
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left">
+                      <thead>
+                        <tr>
+                          <th className={TH_CLS}>Nome</th>
+                          <th className={TH_CLS}>Critérios</th>
+                          <th className={TH_CLS}>Usuários selecionados</th>
+                          <th className={TH_CLS}>Criado em</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {datasets.map((ds) => (
+                          <tr
+                            key={ds.dataset_id}
+                            className={`cursor-pointer transition-colors ${selectedDs === ds.dataset_id ? "bg-davint-50" : "hover:bg-gray-50"}`}
+                            onClick={() => togglePanel(selectedDs, ds.dataset_id, setSelectedDs)}
+                          >
+                            <td className="py-2.5 pr-3 text-xs font-medium text-gray-800">
+                              {ds.name}
+                            </td>
+                            <td className="py-2.5 pr-3">
+                              <div className="flex flex-wrap gap-1">
+                                {ds.criteria.map((c) => (
+                                  <span
+                                    key={c}
+                                    className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-davint-50 text-davint-400"
+                                  >
+                                    {c}
+                                  </span>
+                                ))}
+                              </div>
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-600">
+                              {ds.total_selected}
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-500">
+                              {new Date(ds.created_at).toLocaleDateString("pt-BR")}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  {selectedDs &&
+                    (() => {
+                      const ds = datasets.find((d) => d.dataset_id === selectedDs);
+                      if (!ds) return null;
+                      return (
+                        <DatasetDetail
+                          ds={ds}
+                          onDownload={(fmt) =>
+                            withErrorHandling(
+                              () => downloadDataset(ds.dataset_id, fmt, ds.name),
+                              "Erro ao baixar dataset."
+                            )
+                          }
+                          onDelete={() => handleDeleteDataset(ds.dataset_id)}
+                          onClose={() => setSelectedDs(null)}
+                        />
+                      );
+                    })()}
+                </>
+              )}
+            </Section>
+
+            {/* ── Progresso de Anotação ── */}
+            <Section
+              title="Progresso de Anotação"
+              count={annotations.length}
+              defaultOpen={annotations.length > 0}
+            >
+              {annotations.length === 0 ? (
+                <p className="text-xs text-gray-400 py-2">
+                  Nenhuma anotação encontrada. Comece a anotar na etapa de Anotação.
+                </p>
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left">
+                      <thead>
+                        <tr>
+                          <th className={TH_CLS}>Dataset</th>
+                          <th className={TH_CLS}>Progresso</th>
+                          <th className={TH_CLS}>Conflitos</th>
+                          <th className={TH_CLS}>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {annotations.map((ann) => {
+                          const isComplete =
+                            ann.total > 0 &&
+                            ann.pending === 0 &&
+                            ann.conflicts === ann.conflicts_resolved;
+                          return (
+                            <tr
+                              key={ann.dataset_id}
+                              className={`cursor-pointer transition-colors ${selectedAnn === ann.dataset_id ? "bg-davint-50" : "hover:bg-gray-50"}`}
+                              onClick={() =>
+                                togglePanel(selectedAnn, ann.dataset_id, setSelectedAnn)
+                              }
+                            >
+                              <td className="py-2.5 pr-3 text-xs font-medium text-gray-800">
+                                {ann.dataset_name}
+                              </td>
+                              <td className="py-2.5 pr-3 text-xs text-gray-600">
+                                {ann.annotated}/{ann.total}
+                              </td>
+                              <td className="py-2.5 pr-3 text-xs text-gray-600">
+                                {ann.conflicts_resolved}/{ann.conflicts}
+                              </td>
+                              <td className="py-2.5 pr-3">
+                                <span
+                                  className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${
+                                    isComplete
+                                      ? "bg-green-50 text-green-600"
+                                      : "bg-yellow-50 text-yellow-600"
+                                  }`}
+                                >
+                                  {isComplete ? "Concluído" : "Em andamento"}
+                                </span>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                  {selectedAnn &&
+                    (() => {
+                      const ann = annotations.find((a) => a.dataset_id === selectedAnn);
+                      if (!ann) return null;
+                      return (
+                        <AnnotationDetail
+                          ann={ann}
+                          onExport={(fmt) =>
+                            withErrorHandling(
+                              () => exportAnnotations(ann.dataset_id, fmt),
+                              "Erro ao exportar anotações."
+                            )
+                          }
+                          onDelete={() => handleDeleteDataset(ann.dataset_id)}
+                          onClose={() => setSelectedAnn(null)}
+                        />
+                      );
+                    })()}
+                </>
+              )}
+            </Section>
+
+            {/* ── Dados para Treinamento ── */}
+            <Section
+              title="Dados para Treinamento"
+              count={completedDatasets.length}
+              defaultOpen={completedDatasets.length > 0}
+            >
+              {completedDatasets.length === 0 ? (
+                <p className="text-xs text-gray-400 py-2">
+                  Nenhum dataset pronto para exportar. Um dataset fica disponível aqui quando todos
+                  os comentários forem anotados e todos os conflitos forem resolvidos.
+                </p>
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left">
+                      <thead>
+                        <tr>
+                          <th className={TH_CLS}>Dataset</th>
+                          <th className={TH_CLS}>Comentários</th>
+                          <th className={TH_CLS}>Bots detectados</th>
+                          <th className={TH_CLS}>Anotadores</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {completedDatasets.map((ds) => (
+                          <tr
+                            key={ds.dataset_id}
+                            className={`cursor-pointer transition-colors ${selectedTraining === ds.dataset_id ? "bg-davint-50" : "hover:bg-gray-50"}`}
+                            onClick={() =>
+                              togglePanel(selectedTraining, ds.dataset_id, setSelectedTraining)
+                            }
+                          >
+                            <td className="py-2.5 pr-3 text-xs font-medium text-gray-800">
+                              {ds.dataset_name}
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-600">{ds.total}</td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-600">
+                              {ds.bots_users} usuários / {ds.bots_comments} comentários
+                            </td>
+                            <td className="py-2.5 pr-3 text-xs text-gray-600">
+                              {ds.annotators_count}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  {selectedTraining &&
+                    (() => {
+                      const ds = completedDatasets.find((d) => d.dataset_id === selectedTraining);
+                      if (!ds) return null;
+                      return (
+                        <TrainingDetail
+                          ds={ds}
+                          onExport={(fmt) =>
+                            withErrorHandling(
+                              () => exportReview(ds.dataset_id, fmt),
+                              "Erro ao exportar dataset final."
+                            )
+                          }
+                          onDelete={() => handleDeleteDataset(ds.dataset_id)}
+                          onClose={() => setSelectedTraining(null)}
+                        />
+                      );
+                    })()}
+                </>
+              )}
+            </Section>
+          </>
+        )}
+      </main>
+
+      {showChangePassword && (
+        <ChangePasswordModal
+          onClose={() => setShowChangePassword(false)}
+          onSubmit={(currentPassword, newPassword) =>
+            usersApi.changePassword(
+              { current_password: currentPassword, new_password: newPassword },
+              token!
+            )
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -201,7 +201,7 @@ const TOOLS_CARDS: StageCard[] = [
     description: "Visualize e gerencie todas as coletas, datasets e anotações da plataforma.",
     route: "/data",
     adminOnly: false,
-    available: false,
+    available: true,
     icon: <IconDatabase />,
   },
   {


### PR DESCRIPTION
## Resumo

- Página `/data` com catálogo centralizado de todos os dados da plataforma
- Backend: 4 endpoints (`/data/summary`, `/data/collections`, `/data/datasets`, `/data/annotations`) com queries batch otimizadas (sem N+1)
- Frontend: tabelas compactas com fichas de detalhe ao clicar (export JSON/CSV, delete, progresso, contagem de bots)
- Seções: Coletas, Datasets, Progresso de Anotação, Dados para Treinamento
- Card "Catálogo de Dados" ativado na HomePage
- StatusBadge: tradução de `done`/`importing` para português
- 18 testes cobrindo contrato, auth, listagem compartilhada, consenso bot, conflito resolvido, dataset vazio

## Como testar

- [ ] Acessar `/data` logado como admin e como pesquisador
- [ ] Verificar que o resumo do banco mostra contadores e barra de uso
- [ ] Clicar em uma coleta → ficha com detalhes, export JSON/CSV e botão deletar
- [ ] Clicar em um dataset → ficha com vídeo, critérios, usuários, comentários, export e delete
- [ ] Clicar em progresso de anotação → barra de progresso, anotadores, bots, export e delete
- [ ] Clicar em dados para treinamento → bots detectados (usuários/comentários), export do dataset final
- [ ] Verificar que ao clicar em item de outra seção, o painel anterior fecha
- [ ] Deletar uma coleta em andamento → mensagem de erro (409)
- [ ] `pytest tests/test_data.py` → 18 testes passando