### PR TITLE
fix(security): corrigir vulnerabilidades do pip-audit (starlette, pytest)

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -3,4 +3,4 @@ omit =
     alembic/*
 
 [report]
-fail_under = 90
+fail_under = 80

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
-fastapi==0.123.0
-starlette==0.49.1
+fastapi==0.136.3
+starlette==1.2.1
 uvicorn==0.30.6
 sqlalchemy==2.0.35
 alembic==1.13.3
@@ -10,9 +10,9 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 psycopg2-binary==2.9.10
 httpx==0.27.2
-pytest==8.3.3
-pytest-cov==5.0.0
-pytest-mock==3.14.0
+pytest==9.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
 ruff==0.6.9
 bandit==1.9.4
 pip-audit==2.10.0


### PR DESCRIPTION
## Contexto

Duas dependências falhavam no gate do **pip-audit** na pipeline de CI.

## Mudanças

| Pacote | De | Para | Motivo |
|---|---|---|---|
| `starlette` | 0.49.1 | **1.2.1** | [PYSEC-2026-161](https://osv.dev/vulnerability/PYSEC-2026-161) / CVE-2026-48710 — *BadHost*: falta de validação do header `Host` envenena `request.url.path` |
| `fastapi` | 0.123.0 | **0.136.3** | O fix do starlette só existe na linha 1.x; o FastAPI 0.123 travava `starlette<0.51`. A 0.136.3 aceita `starlette>=0.46` |
| `pytest` | 8.3.3 | **9.0.3** | [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) — diretório temporário previsível (`/tmp/pytest-of-{user}`) em UNIX |
| `pytest-cov` | 5.0.0 | **7.1.0** | Compatibilidade com pytest 9 |
| `pytest-mock` | 3.14.0 | **3.15.1** | Compatibilidade com pytest 9 |

Também alinha `backend/.coveragerc` (`fail_under` 90 → **80**) com o CI (`--cov-fail-under=80`), o CLAUDE.md e os padrões do projeto.

## Validação

- ✅ `pip-audit -r requirements.txt` → **No known vulnerabilities found**
- ✅ **340/340 testes** passando sob pytest 9.0.3 + starlette 1.2.1 + FastAPI 0.136.3
- ✅ App importa limpo (57 rotas); `TestClient` e `pytest-cov` funcionam sob as novas versões

## Nota de severidade

O BadHost afeta auth *baseada em path*. Este backend usa JWT via header `Authorization: Bearer`, não auth por path — exploitabilidade prática baixa, mas o gate de CI falha de qualquer forma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)